### PR TITLE
Alternate fix for reset_modes().

### DIFF
--- a/modules/wolfgame.py
+++ b/modules/wolfgame.py
@@ -161,7 +161,7 @@ def reset_settings():
     dict.clear(var.ORIGINAL_SETTINGS)
 
 def reset_modes(cli):
-    cli.mode(chan, "-m")
+    cli.mode(botconfig.CHANNEL, "-m")
     cmodes = []
     for plr in var.list_players():
         cmodes.append(("-v", plr))
@@ -170,7 +170,6 @@ def reset_modes(cli):
     mass_mode(cli, cmodes)
 
 def reset(cli):
-    chan = botconfig.CHANNEL
     var.PHASE = "none"
 
     for x, timr in var.TIMERS.items():


### PR DESCRIPTION
Oops, sorry, too quick to pull the trigger on the original pull request. This fix has fewer lines of change. "chan" is only ever used as a placeholder for botconfig.CHANNEL in the reset() method anyways. I prefer smaller changes, but it's up to you. It's based on the original pull request so it won't merge automatically onto master now.
