### PR TITLE
Additional fix for issue #4.

### DIFF
--- a/modules/wolfgame.py
+++ b/modules/wolfgame.py
@@ -160,7 +160,13 @@ def reset_settings():
         setattr(var, attr, var.ORIGINAL_SETTINGS[attr])
     dict.clear(var.ORIGINAL_SETTINGS)
 
-def reset_modes(cli):
+def reset_modes_timers(cli):
+    # Reset game timers
+    for x, timr in var.TIMERS.items():
+        timr.cancel()
+    var.TIMERS = {}
+
+    # Reset modes
     cli.mode(botconfig.CHANNEL, "-m")
     cmodes = []
     for plr in var.list_players():
@@ -171,10 +177,6 @@ def reset_modes(cli):
 
 def reset(cli):
     var.PHASE = "none"
-
-    for x, timr in var.TIMERS.items():
-        timr.cancel()
-    var.TIMERS = {}
     
     var.GAME_ID = 0
 
@@ -207,7 +209,7 @@ def forced_exit(cli, nick, *rest):  # Admin Only
     if var.PHASE in ("day", "night"):
         stop_game(cli)
     else:
-        reset_modes(cli)
+        reset_modes_timers(cli)
         reset(cli)
 
     cli.quit("Forced quit from "+nick)
@@ -222,7 +224,7 @@ def restart_program(cli, nick, *rest):
         if var.PHASE in ("day", "night"):
             stop_game(cli)
         else:
-            reset_modes(cli)
+            reset_modes_timers(cli)
             reset(cli)
 
         cli.quit("Forced restart from "+nick)
@@ -825,7 +827,7 @@ def stop_game(cli, winner = ""):
                                                   var.plural(role)))
     cli.msg(chan, " ".join(roles_msg))
 
-    reset_modes(cli)
+    reset_modes_timers(cli)
     
     plrl = []
     for role,ppl in var.ORIGINAL_ROLES.items():
@@ -895,7 +897,7 @@ def chk_win(cli, end_game = True):
     
     if lpl == 0:
         #cli.msg(chan, "No more players remaining. Game ended.")
-        reset_modes(cli)
+        reset_modes_timers(cli)
         reset(cli)
         return True
         
@@ -2668,7 +2670,7 @@ def reset_game(cli, nick, chan, rest):
     if var.PHASE != "join":
         stop_game(cli)
     else:
-        reset_modes(cli)
+        reset_modes_timers(cli)
         reset(cli)
 
 


### PR DESCRIPTION
Moved timer resets with mode resets. Solves the problem of extra messages being sent after a game ends caused by disk I/O lag.
