### PR TITLE
Fix issue where bot would spam services

### DIFF
--- a/modules/common.py
+++ b/modules/common.py
@@ -113,9 +113,13 @@ def connect_callback(cli):
     prepare_stuff = hook("endofmotd", hookid=294)(prepare_stuff)
 
     def mustregain(cli, *blah):
+        if not botconfig.PASS:
+            return
         cli.ns_regain()                    
                     
     def mustrelease(cli, *rest):
+        if not botconfig.PASS:
+            return # prevents the bot from trying to release without a password
         cli.ns_release()
         cli.nick(botconfig.NICK)
 


### PR DESCRIPTION
This very simple fix probably seems redundant or even entirely
pointless, but it actually solves a big design flaw. It does not show
much for freenode, but for other networks (e.g. Esper), where I tweaked
my bot to use ns_ghost instead, it keeps trying to kill off an
(unregistered) nick, without having a password. This effectively causes
spam to the services, and results in an automatic ban.

Quick, simple and effective fix, and does not have any drawback compared to the current version.
