### PR TITLE
Fix !flastgame to prevent people from using !j to get around it

### DIFF
--- a/modules/wolfgame.py
+++ b/modules/wolfgame.py
@@ -3161,9 +3161,12 @@ def flastgame(cli, nick, rest):
             del COMMANDS["join"]
             cmd("join")(lambda *spam: cli.msg(chan, "This command has been disabled by an admin."))
             # manually recreate the command by calling the decorator function
+        if "j" in COMMANDS.keys():
+            del COMMANDS["j"]
+            cmd("j")(lambda *spam: cli.msg(chan, "This command has been disabled by an admin."))
         if "start" in COMMANDS.keys():
             del COMMANDS["start"]
-            cmd("join")(lambda *spam: cli.msg(chan, "This command has been disabled by an admin."))
+            cmd("start")(lambda *spam: cli.msg(chan, "This command has been disabled by an admin."))
         
     cli.msg(chan, "Starting a new game has now been disabled by \02{0}\02.".format(nick))
     var.ADMIN_TO_PING = nick


### PR DESCRIPTION
This was really annoying in ##werewolf-test when I'd !flastgame to do a bugfix and people were able to !j and !start anyway, causing me to lose the position in the logs and such.
