### PR TITLE
Various bugfixes and new mad scientist option

### DIFF
--- a/modules/wolfgame.py
+++ b/modules/wolfgame.py
@@ -1480,8 +1480,28 @@ def del_player(cli, nick, forced_death = False, devoice = True, end_game = True,
                     targets = []
                     target1 = var.ALL_PLAYERS[index - 1]
                     target2 = var.ALL_PLAYERS[index + 1 if index < len(var.ALL_PLAYERS) - 1 else 0]
+                    if len(var.ALL_PLAYERS) >= var.MAD_SCIENTIST_SKIPS_DEAD_PLAYERS:
+                        # determine left player
+                        i = index
+                        while True:
+                            i -= 1
+                            if i < 0:
+                                i = len(var.ALL_PLAYERS) - 1
+                            if var.ALL_PLAYERS[i] in pl or var.ALL_PLAYERS[i] == nick:
+                                target1 = var.ALL_PLAYERS[i]
+                                break
+                        # determine right player
+                        i = index
+                        while True:
+                            i += 1
+                            if i >= len(var.ALL_PLAYERS):
+                                i = 0
+                            if var.ALL_PLAYERS[i] in pl or var.ALL_PLAYERS[i] == nick:
+                                target2 = var.ALL_PLAYERS[i]
+                                break
+
                     if target1 in pl:
-                        if target2 in pl:
+                        if target2 in pl and target1 != target2:
                             if var.ROLE_REVEAL:
                                 r1 = var.get_reveal_role(target1)
                                 an1 = "n" if r1[0] in ("a", "e", "i", "o", "u") else ""

--- a/settings/wolfgame.py
+++ b/settings/wolfgame.py
@@ -52,6 +52,10 @@ WOLF_STEALS_GUN = True  # at night, the wolf can steal steal the victim's bullet
 ROLE_REVEAL = True
 LOVER_WINS_WITH_FOOL = False # if fool is lynched, does their lover win with them?
 
+# Minimum number of players needed for mad scientist to skip over dead people when determining who is next to them
+# Set to 0 to always skip over dead players. Note this is number of players that !joined, NOT number of players currently alive
+MAD_SCIENTIST_SKIPS_DEAD_PLAYERS = 99 
+
 CARE_BOLD = False
 CARE_COLOR = False
 KILL_COLOR = False


### PR DESCRIPTION
Fix One: Don't display duplicate death messages (preferring nightroles over chained kills for purposes of who actually did the kill, which matters for vengeful ghost). Closes #56.

Fix Two: Allow hunter to change their kill at night by using !kill (similar to how wolves can). Formerly, they needed to !retract first in order to change, which was nonintuitive as !retract isn't advertised anywhere.

New: Option for mad scientist to skip over dead players when determining who is adjacent to them. This is based on the number of players who have !joined the game, so you can set it so it only skips over for larger games if needed. The default is 99, which is effectively the same as the current behavior of not skipping. This allows #55 to be implemented if we decided we wanted it.
