### PR TITLE
Fix to allow player_stats to be case-insensitive for nicks.

### DIFF
--- a/modules/wolfgame.py
+++ b/modules/wolfgame.py
@@ -5565,10 +5565,12 @@ def player_stats(cli, nick, chan, rest):
         user = nick
 
     # Find the player's account if possible
-    if user in var.USERS:
-        acc = var.USERS[user]['account']
+    luser = user.lower()
+    lusers = {k.lower(): v for k, v in var.USERS.items()}
+    if luser in lusers:
+        acc = lusers[luser]['account']
         if acc == '*':
-            if user == nick:
+            if luser == nick.lower():
                 cli.notice(nick, 'You are not identified with NickServ.')
             else:
                 cli.notice(nick, user + ' is not identified with NickServ.')


### PR DESCRIPTION
Affects usage of !playerstats when supplying the nick of a user who is in the channel.
