### PR TITLE
Add settings to disable abstain and also limit it

### DIFF
--- a/settings/wolfgame.py
+++ b/settings/wolfgame.py
@@ -44,6 +44,8 @@ PART_STASIS_PENALTY = 1
 
 GOAT_HERDER = True
 
+ABSTAIN_ENABLED = True # whether village can !abstain in order to not vote anyone during day
+LIMIT_ABSTAIN = True # if true, village will be limited to successfully !abstaining a vote only once
 SELF_LYNCH_ALLOWED = True
 HIDDEN_TRAITOR = True
 HIDDEN_AMNESIAC = False # amnesiac still shows as amnesiac if killed even after turning


### PR DESCRIPTION
By default, abstain is enabled and limited to being used once per game. Both of these can be changed in settings.py.

This is to prevent the most egregious abuses of !abstain while still keeping it useful for allowing for ties to not time out day. The limit is added as a setting so it can be disabled for if we wish to allow for village to decide to not vote anyone during day, however defaults to true as we have had no such discussion for allowing that officially and I'm personally very opposed to the idea.
