### PR TITLE
Rolesets are picked randomly + 4 new rolesets

### DIFF
--- a/modules/wolfgame.py
+++ b/modules/wolfgame.py
@@ -1186,7 +1186,6 @@ def stop_game(cli, winner = ""):
                 iwon = False
             elif rol == "fool" and "@" + splr == winner:
                 iwon = True
-                winner = "fool"
             elif rol == "monster" and splr in survived and winner == "monsters":
                 iwon = True
             elif splr in var.LOVERS and splr in survived:
@@ -1318,7 +1317,7 @@ def chk_win(cli, end_game = True):
 
     if lpl < 1:
         message = "Game over! There are no players remaining. Nobody wins."
-        winner = ""
+        winner = "none"
     elif lwolves == lpl / 2:
         if len(var.ROLES["monster"]) > 0:
             plural = "s" if len(var.ROLES["monster"]) > 1 else ""
@@ -4868,14 +4867,14 @@ def start(cli, nick, chann_, rest):
         for gamemode in var.GAMEMODE_VOTES.values():
             if len(villagers) >= var.GAME_MODES[gamemode][1] and len(villagers) <= var.GAME_MODES[gamemode][2]:
                 votes[gamemode] = votes.get(gamemode, 0) + 1
-        voted = [gamemode for gamemode in votes if votes[gamemode] == max(votes.values()) and votes[gamemode] > 2*len(villagers)/5]
+        voted = [gamemode for gamemode in votes if votes[gamemode] == max(votes.values()) and votes[gamemode] >= len(villagers)/2]
         if len(voted):
             cgamemode(cli, random.choice(voted))
         else:
             possiblegamemodes = []
             for gamemode in var.GAME_MODES.keys():
                 if len(villagers) >= var.GAME_MODES[gamemode][1] and len(villagers) <= var.GAME_MODES[gamemode][2] and var.GAME_MODES[gamemode][3] > 0:
-                    possiblegamemodes += [gamemode]*(var.GAME_MODES[gamemode][3]+votes.get(gamemode, 0)*7)
+                    possiblegamemodes += [gamemode]*(var.GAME_MODES[gamemode][3]+votes.get(gamemode, 0)*15)
             cgamemode(cli, random.choice(possiblegamemodes))
 
     for index in range(len(var.ROLE_INDEX) - 1, -1, -1):
@@ -6128,8 +6127,9 @@ if botconfig.DEBUG_MODE or botconfig.ALLOWED_NORMAL_MODE_COMMANDS:
             return
 
         if rest:
-            rest = mode = rest.lower().split()[0]
-            if rest not in var.GAME_MODES.keys():
+            rest = mode = rest.strip().lower()
+            if rest not in var.GAME_MODES.keys() and not rest.startswith("roles"):
+                rest = rest.split()[0]
                 #players can vote by only using partial name
                 matches = 0
                 for gamemode in var.GAME_MODES.keys():

--- a/settings/wolfgame.py
+++ b/settings/wolfgame.py
@@ -339,7 +339,7 @@ class ChangedRolesMode(object):
             except ValueError:
                 raise InvalidModeException("A bad value was used in mode roles.")
 
-@game_mode("default", minp = 4, maxp = 24, likelihood = 10)
+@game_mode("default", minp = 4, maxp = 24, likelihood = 15)
 class DefaultMode(object):
     """Default game mode."""
     def __init__(self):
@@ -510,7 +510,7 @@ class DrunkFireMode(object):
             "sharpshooter"      : (   2   ,   2   ,   3   ,   3   ,   4   ),
             })
 
-@game_mode("noreveal", minp = 4, maxp = 21, likelihood = 2)
+@game_mode("noreveal", minp = 4, maxp = 21, likelihood = 0)
 class NoRevealMode(object):
     """Roles are not revealed when players die."""
     def __init__(self):
@@ -538,7 +538,7 @@ class NoRevealMode(object):
             "cursed villager"   : (   0   ,   1   ,   1   ,   1   ,   1   ,   1   ,   2   ,   2   ),
             })
 
-@game_mode("lycan", minp = 7, maxp = 21, likelihood = 2)
+@game_mode("lycan", minp = 7, maxp = 21, likelihood = 1)
 class LycanMode(object):
     """Many lycans will turn into wolves. Hunt them down before the wolves overpower the village."""
     def __init__(self):
@@ -579,11 +579,12 @@ class AmnesiaMode(object):
 
 # Credits to Metacity for designing and current name
 # Blame arkiwitect for the original name of KrabbyPatty
-@game_mode("aleatoire", minp = 4, maxp = 24, likelihood = 2)
+@game_mode("aleatoire", minp = 4, maxp = 24, likelihood = 3)
 class AleatoireMode(object):
     """Game mode created by Metacity and balanced by woffle."""
     def __init__(self):
-        self.SHARPSHOOTER_CHANCE = 1          #    SHAMAN   , CRAZED SHAMAN
+        self.SHARPSHOOTER_CHANCE = 1
+                                              #    SHAMAN   , CRAZED SHAMAN
         self.TOTEM_CHANCES = {       "death": (     4/20    ,     1/15     ),
                                 "protection": (     8/20    ,     1/15     ),
                                    "silence": (     2/20    ,     1/15     ),
@@ -795,7 +796,7 @@ def update_game_stats(gamemode, size, winner):
             vwins += 1
         elif winner == "monsters":
             mwins += 1
-        elif winner == "fool":
+        elif winner.startswith("@"):
             fwins += 1
         total += 1
 


### PR DESCRIPTION
When the game is started, it makes a list of all possible game modes for that number of players and picks one randomly. Players can use the !game command to vote for one game mode before the game starts, which makes it a lot more likely to appear. Also if more than 2/5 of the players (about half) vote for a game mode it will be guaranteed to be picked (assuming there are enough players).

There are also 4 new game modes: foolish, mad, drunkfire, and lycan. They could possibly use some balancing but they have been tested a bit. These 3 modes will never be randomly picked: rapidfire, drunkfire, amnesia. You can still vote for them, and if the 2/5 majority votes for it then it will be picked.

Also, it fixes up !gstats to log stats per game mode, since if not the stats wouldn't mean much. The current database needs to be either moved or migrated or else it will error.

Feedback appreciated :), don't merge it yet, it could maybe use some more testing. Also once woffle adds randomized game modes, these new game modes will need changes to support that.
