### PR TITLE
Change KrabbyPatty roleset name to aleatoire

### DIFF
--- a/settings/wolfgame.py
+++ b/settings/wolfgame.py
@@ -467,8 +467,8 @@ class AmnesiaMode(object):
             })
 
 
-# Credits to Metacity for designing
-# Blame arkiwitect for the name
+# Credits to Metacity for designing and current name
+# Blame arkiwitect for the original name of KrabbyPatty
 @game_mode("aleatoire")
 class AleatoireMode(object):
     def __init__(self):


### PR DESCRIPTION
Exactly what it says on the tin. Something French like aléatoire (w/o diacritics) seems more sensible/elegant IMO.
