### PR TITLE
Add ability to carry settings from botconfig to var.

### DIFF
--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -1,0 +1,15 @@
+import botconfig
+from settings import wolfgame as var
+
+# Todo: Allow game modes to be set via config
+
+# Carry over settings from botconfig into settings/wolfgame.py
+
+for setting, value in botconfig.__dict__.items():
+    if not setting.isupper():
+        continue # Not a setting
+    if not setting in var.__dict__.keys():
+        continue # Don't carry over config-only settings
+
+    # If we got that far, it's valid
+    setattr(var, setting, value)


### PR DESCRIPTION
This change allows `settings/wolfgame.py` to have the default settings, without any modification as to how it currently is, and add differing settings in botconfig. At runtime, it will check if there are settings able to be copied from the config, and copy them over, overriding the same setting

This does not affect in any way how it works right now, and the old way of changing settings directly still works.

There are checks performed to make sure that everything is of the proper type, but no further checks are made. But then, there are no checks performed when editing `settings/wolfgame.py` directly.

It's not currently possible to create game modes from the config, and some settings cannot be set using the config. I do believe however that it's pretty good the way it is.

This will allow to have one instance of (default) settings and yet be able to share the same code among different networks and/or channels, using different settings in the end.
