### PR TITLE
Move argument parsing out of botconfig.

### DIFF
--- a/botconfig.py.example
+++ b/botconfig.py.example
@@ -20,19 +20,3 @@ ALLOWED_NORMAL_MODE_COMMANDS = []  # debug mode commands to be allowed in normal
 
 OWNERS = ("unaffiliated/wolfbot_admin1",)  # the comma is required at the end if there is one owner
 ADMINS = ("unaffiliated/wolfbot_admin2", "unaffiliated/wolfbot_admin3")  # glob syntax supported (wildcards)
-
-# Stop editing here
-
-# Argument --debug means start in debug mode
-#          --verbose means to print a lot of stuff (when not in debug mode)
-import argparse
-parser = argparse.ArgumentParser()
-parser.add_argument('--debug', action='store_true')
-parser.add_argument('--sabotage', action='store_true')
-parser.add_argument('--verbose', action='store_true')
-
-args = parser.parse_args()
-DEBUG_MODE = args.debug if not DISABLE_DEBUG_MODE else False
-VERBOSE_MODE = args.verbose
-
-DEFAULT_MODULE = "sabotage" if args.sabotage else "wolfgame"

--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -1,3 +1,4 @@
+import argparse
 import botconfig
 from settings import wolfgame as var
 
@@ -13,3 +14,19 @@ for setting, value in botconfig.__dict__.items():
 
     # If we got that far, it's valid
     setattr(var, setting, value)
+
+# Handle launch parameters
+
+# Argument --debug means start in debug mode
+#          --verbose means to print a lot of stuff (when not in debug mode)
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--debug', action='store_true')
+parser.add_argument('--sabotage', action='store_true')
+parser.add_argument('--verbose', action='store_true')
+
+args = parser.parse_args()
+botconfig.DEBUG_MODE = args.debug if not botconfig.DISABLE_DEBUG_MODE else False
+botconfig.VERBOSE_MODE = args.verbose
+
+botconfig.DEFAULT_MODULE = "sabotage" if args.sabotage else "wolfgame"


### PR DESCRIPTION
To reduce unnecessary stuff in botconfig, I moved the launch argument parsing out of it and into `modules/__init__.py`. Nothing else was affected, and launch arguments can still be accessed using `botconfig.DEBUG_MODE` for example.
