### PR TITLE
Allow admins and owners tracking via account.

### DIFF
--- a/botconfig.py.example
+++ b/botconfig.py.example
@@ -20,3 +20,6 @@ ALLOWED_NORMAL_MODE_COMMANDS = []  # debug mode commands to be allowed in normal
 
 OWNERS = ("unaffiliated/wolfbot_admin1",)  # the comma is required at the end if there is one owner
 ADMINS = ("unaffiliated/wolfbot_admin2", "unaffiliated/wolfbot_admin3")  # glob syntax supported (wildcards)
+
+OWNERS_ACCOUNTS = ("1owner_acc",)
+ADMINS_ACCOUNTS = ("1admin_acc", "2admin_acc")

--- a/modules/wolfgame.py
+++ b/modules/wolfgame.py
@@ -5500,7 +5500,7 @@ def get_help(cli, rnick, rest):
             not fn[0].owner_only and name not in fn[0].aliases):
             fns.append("\u0002"+name+"\u0002")
     afns = []
-    if is_admin(cloak) or cloak in botconfig.OWNERS: # todo - is_owner
+    if is_admin(nick):
         for name, fn in COMMANDS.items():
             if fn[0].admin_only and name not in fn[0].aliases:
                 afns.append("\u0002"+name+"\u0002")
@@ -5522,9 +5522,23 @@ def on_invite(cli, nick, something, chan):
         cli.join(chan)
 
 
-def is_admin(cloak):
-    return bool([ptn for ptn in botconfig.OWNERS+botconfig.ADMINS if fnmatch.fnmatch(cloak.lower(), ptn.lower())])
+def is_admin(nick):
+    if nick not in var.USERS.keys():
+        return False
+    if [ptn for ptn in botconfig.OWNERS+botconfig.ADMINS if fnmatch.fnmatch(var.USERS[nick]["cloak"].lower(), ptn.lower())]:
+        return True
+    if [ptn for ptn in botconfig.OWNERS_ACCOUNTS+botconfig.ADMINS_ACCOUNTS if fnmatch.fnmatch(var.USERS[nick]["account"].lower(), ptn.lower())]:
+        return True
+    return False
 
+def is_owner(nick):
+    if nick not in var.USERS.keys():
+        return False
+    if [ptn for ptn in botconfig.OWNERS if fnmatch.fnmatch(var.USERS[nick]["cloak"].lower(), ptn.lower())]:
+        return True
+    if [ptn for ptn in botconfig.OWNERS_ACCOUNTS if fnmatch.fnmatch(var.USERS[nick]["account"].lower(), ptn.lower())]:
+        return True
+    return False
 
 @cmd("admins", "ops")
 def show_admins(cli, nick, chan, rest):
@@ -5552,7 +5566,7 @@ def show_admins(cli, nick, chan, rest):
         if not var.ADMIN_PINGING:
             return
 
-        if is_admin(cloak) and "G" not in status and user != botconfig.NICK:
+        if is_admin(user) and "G" not in status and user != botconfig.NICK:
             admins.append(user)
 
     @hook("endofwho", hookid=4)
@@ -6097,7 +6111,7 @@ def _say(cli, raw_nick, rest, command, action=False):
 
     (target, message) = rest
 
-    if not is_admin(host):
+    if not is_admin(nick):
         if nick not in var.USERS:
             pm(cli, nick, "You have to be in {0} to use this command.".format(
                 botconfig.CHANNEL))
@@ -6262,7 +6276,7 @@ if botconfig.DEBUG_MODE or botconfig.ALLOWED_NORMAL_MODE_COMMANDS:
         did = False
         if PM_COMMANDS.get(cmd) and not PM_COMMANDS[cmd][0].owner_only:
             if (PM_COMMANDS[cmd][0].admin_only and nick in var.USERS and
-                not is_admin(var.USERS[nick]["cloak"])):
+                not is_admin(nick)):
                 # Not a full admin
                 cli.notice(nick, "Only full admins can force an admin-only command.")
                 return
@@ -6280,7 +6294,7 @@ if botconfig.DEBUG_MODE or botconfig.ALLOWED_NORMAL_MODE_COMMANDS:
             #    chk_nightdone(cli)
         elif COMMANDS.get(cmd) and not COMMANDS[cmd][0].owner_only:
             if (COMMANDS[cmd][0].admin_only and nick in var.USERS and
-                not is_admin(var.USERS[nick]["cloak"])):
+                not is_admin(nick)):
                 # Not a full admin
                 cli.notice(nick, "Only full admins can force an admin-only command.")
                 return
@@ -6319,7 +6333,7 @@ if botconfig.DEBUG_MODE or botconfig.ALLOWED_NORMAL_MODE_COMMANDS:
         cmd = rst.pop(0).lower().replace(botconfig.CMD_CHAR, "", 1)
         if PM_COMMANDS.get(cmd) and not PM_COMMANDS[cmd][0].owner_only:
             if (PM_COMMANDS[cmd][0].admin_only and nick in var.USERS and
-                not is_admin(var.USERS[nick]["cloak"])):
+                not is_admin(nick)):
                 # Not a full admin
                 cli.notice(nick, "Only full admins can force an admin-only command.")
                 return
@@ -6332,7 +6346,7 @@ if botconfig.DEBUG_MODE or botconfig.ALLOWED_NORMAL_MODE_COMMANDS:
             #    chk_nightdone(cli)
         elif cmd.lower() in COMMANDS.keys() and not COMMANDS[cmd][0].owner_only:
             if (COMMANDS[cmd][0].admin_only and nick in var.USERS and
-                not is_admin(var.USERS[nick]["cloak"])):
+                not is_admin(nick)):
                 # Not a full admin
                 cli.notice(nick, "Only full admins can force an admin-only command.")
                 return

--- a/settings/wolfgame.py
+++ b/settings/wolfgame.py
@@ -198,8 +198,11 @@ LYNCH_MESSAGES_NO_REVEAL = ("The villagers, after much debate, finally decide on
 import botconfig
 
 RULES = (botconfig.CHANNEL + " channel rules: http://wolf.xnrand.com/rules")
-botconfig.DENY = {} #these are set in here ... for now
+botconfig.DENY = {} # These are set in here ... for now
 botconfig.ALLOW = {}
+
+botconfig.DENY_ACCOUNTS = {}
+botconfig.ALLOW_ACCOUNTS = {}
 
 # Other settings:
 


### PR DESCRIPTION
This change allows tracking of admins and owners with accounts instead of hostnames. Hostnames still work.

Nothing else in the commands need to be changed, as the decorators themselves were altered to properly check for account. The `is_admin` command was modified to take this into account (no pun intended) and now requires a nickname to be fed (previously a hostname). While I was there, I also made `is_owner` (currently not used anywhere).

There was discussion a few minutes ago in -dev over whether or not !fallow and !fdeny should be modified regarding this change, and we agreed to leave those alone for now.

It's not currently possible to check for accounts if the user and the bot don't share at least a channel. I haven't found a sane way to do that.
