### PR TITLE
Adds ability for the bot to be in multiple channels.

### DIFF
--- a/botconfig.py.example
+++ b/botconfig.py.example
@@ -23,3 +23,7 @@ ADMINS = ("unaffiliated/wolfbot_admin2", "unaffiliated/wolfbot_admin3")  # glob 
 
 OWNERS_ACCOUNTS = ("1owner_acc",)
 ADMINS_ACCOUNTS = ("1admin_acc", "2admin_acc")
+
+ALT_CHANNELS = ""
+
+ALLOWED_ALT_CHANNELS_COMMANDS = []

--- a/modules/common.py
+++ b/modules/common.py
@@ -98,6 +98,7 @@ def connect_callback(cli):
 
     def prepare_stuff(*args):    
         cli.join(botconfig.CHANNEL)
+        cli.join(botconfig.ALT_CHANNELS)
         cli.msg("ChanServ", "op "+botconfig.CHANNEL)
         
         cli.cap("REQ", "extended-join")

--- a/tools/decorators.py
+++ b/tools/decorators.py
@@ -27,14 +27,29 @@ def generate(fdict, permissions=True, **kwargs):
                 else:
                     nick = ""
                     cloak = ""
+                if len(largs) > 3 and largs[2]:
+                    chan = largs[2]
+                else:
+                    chan = ""
+                if not raw_nick and len(largs) > 1 and largs[1]:
+                    largs[1] = nick
+                if not permissions:
+                    return f(*largs)
+                if chan and not chan == botconfig.CHANNEL and not admin_only and not owner_only:
+                    if "" in s:
+                        return # Don't have empty commands triggering in other channels
+                    allowed = False
+                    for cmdname in s:
+                        if cmdname in botconfig.ALLOWED_ALT_CHANNELS_COMMANDS:
+                            allowed = True
+                            break
+                    if not allowed:
+                        return
                 if nick in var.USERS.keys():
                     acc = var.USERS[nick]["account"]
                 else:
                     acc = None
-                if not raw_nick and len(largs) > 1 and largs[1]:
-                    largs[1] = nick
-                    #if largs[1].startswith("#"):
-                if not permissions or "" in s:
+                if "" in s:
                     return f(*largs)
                 if cloak:
                     for pattern in botconfig.DENY.keys():


### PR DESCRIPTION
This change allows the bot to be in multiple channels at once. Only the main channel (`botconfig.CHANNEL`) can be used to play. Admin and owner-only commands can be used in any channel, along with any command specified in `botconfig.ALLOWED_ALT_CHANNELS_COMMANDS`.
