### PR TITLE
Huge overhaul to the system to use accounts.

### DIFF
--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -30,3 +30,7 @@ botconfig.DEBUG_MODE = args.debug if not botconfig.DISABLE_DEBUG_MODE else False
 botconfig.VERBOSE_MODE = args.verbose
 
 botconfig.DEFAULT_MODULE = "sabotage" if args.sabotage else "wolfgame"
+
+# Initialize Database
+
+var.init_db()

--- a/tools/decorators.py
+++ b/tools/decorators.py
@@ -45,36 +45,36 @@ def generate(fdict, permissions=True, **kwargs):
                             break
                     if not allowed:
                         return
-                if nick in var.USERS.keys():
+                if nick in var.USERS.keys() and var.USERS[nick]["account"] != "*":
                     acc = var.USERS[nick]["account"]
                 else:
                     acc = None
                 if "" in s:
                     return f(*largs)
-                if cloak:
-                    for pattern in botconfig.DENY.keys():
-                        if fnmatch.fnmatch(cloak.lower(), pattern.lower()):
-                            for cmdname in s:
-                                if cmdname in botconfig.DENY[pattern]:
-                                    largs[0].notice(nick, "You do not have permission to use that command.")
-                                    return
-                    for pattern in botconfig.ALLOW.keys():
-                        if fnmatch.fnmatch(cloak.lower(), pattern.lower()):
-                            for cmdname in s:
-                                if cmdname in botconfig.ALLOW[pattern]:
-                                    return f(*largs)  # no questions
                 if acc:
-                    for pattern in botconfig.DENY_ACCOUNTS.keys():
+                    for pattern in var.DENY_ACCOUNTS.keys():
                         if fnmatch.fnmatch(acc.lower(), pattern.lower()):
                             for cmdname in s:
-                                if cmdname in botconfig.DENY_ACCOUNTS[pattern]:
+                                if cmdname in var.DENY_ACCOUNTS[pattern]:
                                     largs[0].notice(nick, "You do not have permission to use that command.")
                                     return
-                    for pattern in botconfig.ALLOW_ACCOUNTS.keys():
+                    for pattern in var.ALLOW_ACCOUNTS.keys():
                         if fnmatch.fnmatch(acc.lower(), pattern.lower()):
                             for cmdname in s:
-                                if cmdname in botconfig.ALLOW_ACCOUNTS[pattern]:
+                                if cmdname in var.ALLOW_ACCOUNTS[pattern]:
                                     return f(*largs)
+                if not var.ACCOUNTS_ONLY and cloak:
+                    for pattern in var.DENY.keys():
+                        if fnmatch.fnmatch(cloak.lower(), pattern.lower()):
+                            for cmdname in s:
+                                if cmdname in var.DENY[pattern]:
+                                    largs[0].notice(nick, "You do not have permission to use that command.")
+                                    return
+                    for pattern in var.ALLOW.keys():
+                        if fnmatch.fnmatch(cloak.lower(), pattern.lower()):
+                            for cmdname in s:
+                                if cmdname in var.ALLOW[pattern]:
+                                    return f(*largs)  # no questions
                 if owner_only:
                     if var.is_owner(nick):
                         return f(*largs)


### PR DESCRIPTION
This change started out small but is now much larger. It does a complete overhaul of the whole system to make everything work with accounts over hostnames. Hostnames are still used, albeit only as a fallback method if the user is not logged in. Stasis uses both account and hosts at all times. Here is what was modified (might forget some, did a lot of changes):
- Support for account for the following commands: `notice`, `simple`, `away`/`back`/`out`/`in`, `fallow`/`fdeny` and `fstasis`.
- New `ACCOUNTS_ONLY` setting, which completely ignores hostmasks (except for stasis, which is special case) and disallows unidentified players from joining the game. They can still be fjoined.
- Admin, owner, allow and deny support for accounts. Admin and owner checks for both, while allow and deny are subject to the same restrictions as the rest.
- Allow and deny dicts were moved to `botconfig` (previously `settings.wolfgame`). All references to the dicts were updated. Thanks to one of my previous commits (from Pull Request #86 ), those dicts can be set directly from the config.
- New `LEAVE_ON_LOGOUT` setting (defaulting to off), which will remove the user from the game if they log out. Added matching quit message (for now a placeholder), stasis penalty and grace period to identify back.
- All variables have their proper database to carry over between restarts.
- Many other things I might have forgotten.

Right now not fully tested. I am committing so this can be checked and commented on, and if we find bugs I'll update this.

Don't merge yet. Discuss in -dev.
