### PR TITLE
Added an automatic mode toggle.

### DIFF
--- a/settings/wolfgame.py
+++ b/settings/wolfgame.py
@@ -46,6 +46,8 @@ PART_STASIS_PENALTY = 1
 ACC_STASIS_PENALTY = 1
 LEAVE_ON_LOGOUT = False # If True, the bot will consider a NickServ logout as a quit
 QUIET_DEAD_PLAYERS = False
+# The bot will automatically toggle those modes of people joining
+AUTO_TOGGLE_MODES = ""
 
 GOAT_HERDER = True
 


### PR DESCRIPTION
This small change allows ops (and other modes such as halfop, admin/protected or whatever other mode, provided the bot can change it) to join the game and be automatically deopped, then re-opped on game end. The setting can be a string (default: empty string), a list, tuple or set. If a string, it should contain all the characters for the modes. Another iterable should contain one-character items of the modes. Any invalid mode character fed in is ignored. The prefix (such as @ for +o) is a valid value.

It keeps track of every mode each user in the (main) channel has in `var.USERS[nick]["modes"]` and, when it removes them, stores them in `var.USERS[nick]["moded"]` to apply them back later. Both of these variables are sets, empty by default.

Thanks to bcode for feedback on how to properly handle the modes.
