### PR TITLE
Disallow !quit immediately after starting to avoid accidents

### DIFF
--- a/modules/wolfgame.py
+++ b/modules/wolfgame.py
@@ -2731,9 +2731,9 @@ def leave_game(cli, nick, chan, rest):
         else:
             population = (" New player count: \u0002{0}\u0002").format(lpl)
     else:
-        dur = (datetime.now() - var.GAME_START_TIME).total_seconds()
-        if var.START_QUIT_DELAY and dur < var.START_QUIT_DELAY:
-            cli.notice(nick, "The game already started!")
+        dur = int(var.START_QUIT_DELAY - (datetime.now() - var.GAME_START_TIME).total_seconds())
+        if var.START_QUIT_DELAY and dur:
+            cli.notice(nick, "The game already started! If you still want to quit, try again in {0} second{1}.".format(dur, "" if dur == 1 else "s"))
             return
         population = ""
     if nick not in var.list_players() or nick in var.DISCONNECTED.keys():  # not playing

--- a/modules/wolfgame.py
+++ b/modules/wolfgame.py
@@ -2731,6 +2731,10 @@ def leave_game(cli, nick, chan, rest):
         else:
             population = (" New player count: \u0002{0}\u0002").format(lpl)
     else:
+        dur = (datetime.now() - var.GAME_START_TIME).total_seconds()
+        if var.START_QUIT_DELAY and dur < var.START_QUIT_DELAY:
+            cli.notice(nick, "The game already started!")
+            return
         population = ""
     if nick not in var.list_players() or nick in var.DISCONNECTED.keys():  # not playing
         cli.notice(nick, "You're not currently playing.")

--- a/settings/wolfgame.py
+++ b/settings/wolfgame.py
@@ -39,6 +39,7 @@ PM_WARN_IDLE_TIME = 240
 PART_GRACE_TIME = 30
 QUIT_GRACE_TIME = 30
 ACC_GRACE_TIME = 30
+START_QUIT_DELAY = 10
 #  controls how many people it does in one /msg; only works for messages that are the same
 MAX_PRIVMSG_TARGETS = 4
 LEAVE_STASIS_PENALTY = 1


### PR DESCRIPTION
Adds a setting to disallow quitting for a few seconds after the game started to prevent accidents with people doing `!quit` when they don't want to quit *during* the actual game for some reason.

This happens every now and then; might be a good idea to have a method to avoid it.