### PR TITLE
Huge overhaul to the decorators (+ a lot of small changes).

### DIFF
--- a/modules/wolfgame.py
+++ b/modules/wolfgame.py
@@ -591,10 +591,10 @@ def mark_prefer_notice(cli, nick, chan, rest):
     cli.notice(nick, "The bot will now always NOTICE you.")
 
 def is_user_notice(nick):
-    if nick in USERS and USERS[nick]["account"] and USERS[nick]["account"] != "*":
-        if USERS[nick]["account"] in PREFER_NOTICE_ACCS:
+    if nick in var.USERS and var.USERS[nick]["account"] and var.USERS[nick]["account"] != "*":
+        if var.USERS[nick]["account"] in var.PREFER_NOTICE_ACCS:
             return True
-    if nick in USERS and USERS[nick]["cloak"] in PREFER_NOTICE and not ACCOUNTS_ONLY:
+    if nick in var.USERS and var.USERS[nick]["cloak"] in var.PREFER_NOTICE and not var.ACCOUNTS_ONLY:
         return True
     return False
 

--- a/modules/wolfgame.py
+++ b/modules/wolfgame.py
@@ -583,7 +583,8 @@ def away(cli, nick, chan, rest):
     """Use this to activate your away status (so you aren't pinged)."""
     nick, _, _, cloak = parse_nick(nick)
     if var.OPT_IN_PING:
-        cli.notice(nick, "Please use {0}in and {0}out to opt in or out of the ping list.".format(botconfig.CMD_CHAR))
+        if not rest: # don't want to trigger on unrelated messages
+            cli.notice(nick, "Please use {0}in and {0}out to opt in or out of the ping list.".format(botconfig.CMD_CHAR))
         return
     if nick in var.USERS:
         cloak = var.USERS[nick]["cloak"]
@@ -623,7 +624,8 @@ def back_from_away(cli, nick, chan, rest):
     """Unsets your away status."""
     nick, _, _, cloak = parse_nick(nick)
     if var.OPT_IN_PING:
-        cli.notice(nick, "Please use {0}in and {0}out to opt in or out of the ping list.".format(botconfig.CMD_CHAR))
+        if not rest:
+            cli.notice(nick, "Please use {0}in and {0}out to opt in or out of the ping list.".format(botconfig.CMD_CHAR))
         return
     if nick in var.USERS:
         cloak = var.USERS[nick]["cloak"]
@@ -659,7 +661,8 @@ def get_in(cli, nick, chan, rest):
     """Puts yourself in the ping list."""
     nick, _, _, cloak = parse_nick(nick)
     if not var.OPT_IN_PING:
-        cli.notice(nick, "Please use {0}away and {0}back to mark yourself as away or back.".format(botconfig.CMD_CHAR))
+        if not rest:
+            cli.notice(nick, "Please use {0}away and {0}back to mark yourself as away or back.".format(botconfig.CMD_CHAR))
         return
     if nick in var.USERS:
         cloak = var.USERS[nick]["cloak"]
@@ -694,7 +697,8 @@ def get_out(cli, nick, chan, rest):
     """Removes yourself from the ping list."""
     nick, _, _, cloak = parse_nick(nick)
     if not var.OPT_IN_PING:
-        cli.notice(nick, "Please use {0}away and {0}back to mark yourself as away or back.".format(botconfig.CMD_CHAR))
+        if not rest:
+            cli.notice(nick, "Please use {0}away and {0}back to mark yourself as away or back.".format(botconfig.CMD_CHAR))
         return
     if nick in var.USERS:
         cloak = var.USERS[nick]["cloak"]
@@ -3860,9 +3864,10 @@ def kill(cli, nick, chan, rest):
         role = var.get_role(nick)
     except KeyError:
         role = None
-    if role in var.WOLFCHAT_ROLES and role not in ("wolf", "werecrow", "alpha wolf"):
+    wolfroles = var.WOLF_ROLES - ["wolf cub"]
+    if role in var.WOLFCHAT_ROLES and role not in wolfroles:
         return  # they do this a lot.
-    if role not in ("wolf", "werecrow", "alpha wolf", "hunter") and nick not in var.VENGEFUL_GHOSTS.keys():
+    if role not in wolfroles + ["hunter"] and nick not in var.VENGEFUL_GHOSTS.keys():
         pm(cli, nick, "Only a wolf, hunter, or dead vengeful ghost may use this command.")
         return
     if var.PHASE != "night":
@@ -3875,13 +3880,13 @@ def kill(cli, nick, chan, rest):
     if nick in var.SILENCED:
         pm(cli, nick, "You have been silenced, and are unable to use any special powers.")
         return
-    if role in ("wolf", "werecrow", "alpha wolf") and var.DISEASED_WOLVES:
+    if role in wolfroles and var.DISEASED_WOLVES:
         pm(cli, nick, "You are feeling ill, and are unable to kill anyone tonight.")
         return
     pieces = re.split(" +",rest)
     victim = pieces[0]
     victim2 = None
-    if role in ("wolf", "werecrow", "alpha wolf") and var.ANGRY_WOLVES:
+    if role in wolfroles and var.ANGRY_WOLVES:
         if len(pieces) > 1:
             if len(pieces) > 2 and pieces[1].lower() == "and":
                 victim2 = pieces[2]
@@ -3923,7 +3928,7 @@ def kill(cli, nick, chan, rest):
             pm(cli, nick, "You must target a villager.")
             return
 
-    if role in ("wolf", "werecrow", "alpha wolf"):
+    if role in wolfroles:
         wolfchatwolves = var.list_players(var.WOLFCHAT_ROLES)
         if victim in wolfchatwolves or victim2 in wolfchatwolves:
             pm(cli, nick, "You may only kill villagers, not other wolves.")
@@ -3964,7 +3969,7 @@ def kill(cli, nick, chan, rest):
     else:
         pm(cli, nick, "You have selected \u0002{0}\u0002 to be killed.".format(victim))
         var.LOGGER.logBare(nick, "SELECT", victim)
-        if var.ANGRY_WOLVES and role in ("wolf", "werecrow", "alpha wolf"):
+        if var.ANGRY_WOLVES and role in wolfroles:
             pm(cli, nick, "You are angry tonight and may kill a second target. Use kill <nick1> and <nick2> to select multiple targets.")
     chk_nightdone(cli)
 

--- a/modules/wolfgame.py
+++ b/modules/wolfgame.py
@@ -5978,12 +5978,11 @@ def get_help(cli, rnick, chan, rest):
     splitted = re.split(" +", rest, 1)
     cname = splitted.pop(0)
     rest = splitted[0] if splitted else ""
-    found = False
     if cname:
         if cname in COMMANDS.keys():
-            found = True
             for fn in COMMANDS[cname]:
                 if fn.__doc__:
+                    got = True
                     if callable(fn.__doc__):
                         msg = botconfig.CMD_CHAR+cname+": "+fn.__doc__(rest)
                         if nick == botconfig.CHANNEL:
@@ -5998,17 +5997,22 @@ def get_help(cli, rnick, chan, rest):
                         cli.notice(nick, msg)
                     return
                 else:
+                    got = False
                     continue
             else:
-                if not found:
-                    msg = "Command not found."
+                if got:
+                    return
+                elif chan == nick:
+                    pm(cli, nick, "Documentation for this command is not available.")
                 else:
-                    msg = "Documentation for this command is not available."
-                if chan == nick:
-                    pm(cli, nick, msg)
-                else:
-                    cli.notice(nick, msg)
-                return
+                    cli.notice(nick, "Documentation for this command is not available.")
+
+        elif chan == nick:
+            pm(cli, nick, "Command not found.")
+        else:
+            cli.notice(nick, "Command not found.")
+        return
+
     # if command was not found, or if no command was given:
     for name, fn in COMMANDS.items():
         if ((name in ("away", "back") and var.OPT_IN_PING) or

--- a/settings/wolfgame.py
+++ b/settings/wolfgame.py
@@ -245,32 +245,6 @@ PING_IN_ACCS = [] # accounts of people who have opted in for ping
 
 is_role = lambda plyr, rol: rol in ROLES and plyr in ROLES[rol]
 
-def pm(cli, target, message):  # message either privmsg or notice, depending on user settings
-    if is_fake_nick(target) and botconfig.DEBUG_MODE:
-        print("[{0}] Would send message to fake nick {1}: {2}".format(
-            time.strftime("%d/%b/%Y %H:%M:%S"),
-            target,
-            message), file=sys.stderr)
-
-        return
-
-    if is_user_notice(target):
-        cli.notice(target, message)
-        return
-
-    cli.msg(target, message)
-
-def is_user_notice(nick):
-    if nick in USERS and USERS[nick]["account"] and USERS[nick]["account"] != "*":
-        if USERS[nick]["account"] in PREFER_NOTICE_ACCS:
-            return True
-    if nick in USERS and USERS[nick]["cloak"] in PREFER_NOTICE and not ACCOUNTS_ONLY:
-        return True
-    return False
-
-def is_fake_nick(who):
-    return re.match("[0-9]+", who)
-
 def is_admin(nick):
     if nick not in USERS.keys():
         return False

--- a/tools/decorators.py
+++ b/tools/decorators.py
@@ -76,10 +76,6 @@ def generate(fdict, permissions=True, **kwargs):
                         if nick in var.ROLES[role]:
                             break
                     else:
-                        if len(roles) == 1:
-                            var.pm(largs[0], nick, "Only a{0} {1} may use this command.".format("n" if roles[0][0] in "aeiou" else "", roles[0]))
-                        else:
-                            var.pm(largs[0], nick, "Only a{0} {1} or {2} may use this command.".format("n" if roles[0][0] in "aeiou" else "", ", ".join(roles[:-1]), roles[-1]))
                         return
                 if acc:
                     for pattern in var.DENY_ACCOUNTS.keys():


### PR DESCRIPTION
This change gets entirely rid of PM commands decorators and adds a number of switches to the decorators. A number of new parameters were added to the decorators and a lot of cluster was removed from the functions themselves (they are now in the decorators).

The `chan` (Default: `True`) and `pm` (Default: `False`) parameters can be used to define if a command should be used as a channel and/or PM command. Parameters given to the functions are the same as before: `cli, nick, chan, rest` and PM commands are `cli, nick, nick, rest` to ensure that always 4 parameters are fed. The `game`, `join`, `none` and `playing` parameters were also added. More info below. The `roles` parameters (defaulting to an empty tuple) expects a tuple, although a list or set will also work. They are used to determine which roles are allowed to use the command. Leaving it unspecified means anyone can use it.

The error messages being noticed if you use a role command you don't have access to have been removed. Closes #76.

Possible combinations of `join`, `none`, `game` and `playing` are as follow:

`game` is `True` and `join` is True:
- Phase is not `join`, `day` or `night` - Notices `"No game is currently running."`

`game` is `True`:
- Phase is not `day` or `night` - Notices `"No game is currently running."`

`join` is `True` and `none` is `False`:
- Phase is `none` - Notices `"No game is currently running."`
- Phase is not `join` and `game` is not `True` - Notices `"Werewolf is already in play."`

`playing` is `True` and `nick` is not playing:
- Notices `"You're not currently playing."`

If one condition triggers, the others will not. Priority is from top to bottom.

A lot of small changes were done, and this closes #64 in the process.

Small, mostly unrelated changes:

- Added back admin_only switch for `fdie` and `frestart` and special-cased fake nick `<console>`.
- Added settings in the variables for which roles are seen as wolf and as the default role.
- A new `DEFAULT_SEEN_AS_VILL` setting, defaulting to `True`, was added. This ensure people who would normally be seen as the default role, sometimes cultist, will now always be seen as villager.
- Fixed seer and oracle seeing the amnesiac's final role before turning. Augur is unchanged.
- Fixed a bug related to the new totem chances weight (that I added recently) arising with the use of `!frole`.
- Added `'*'` wildcard for `!force` and `!rforce`, both of which match all players.
- Removed module imports that were no longer used.
- Changed all `'single-quoted'` commands to `"double-quoted"` for consistency (and easier Ctrl+F searching).
- Renamed `cmd` variable in `force` and `rforce` to avoid confusion.
- Tweaked `kill` command to use the variables instead of hardcoded roles.
- Removed error message when using `in` or `out` if disabled, unless it's the only word. Same for `away` and `back` if disabled.
- Probably much more that I can't remember now.