### PR TITLE
Remove some restrictions on who can be assassin

### DIFF
--- a/modules/wolfgame.py
+++ b/modules/wolfgame.py
@@ -5134,13 +5134,22 @@ def transition_night(cli):
         pl = ps[:]
         random.shuffle(pl)
         pl.remove(ass)
-        if ass in var.PLAYERS and not is_user_simple(ass):
-            pm(cli, ass, ('You are an \u0002assassin\u0002. Choose a target with ' +
-                          '"target <nick>". If you die you will take out your target with you. ' +
-                          'If your target dies you may choose another one.'))
+        role = var.get_role(ass)
+        if role == "village drunk":
+            var.TARGETED[ass] = random.choice(pl)
+            message = ("You are an \u0002assassin\u0002. In your drunken stupor you have selected " +
+                       "\u0002{0}\u0002 as your target.").format(var.TARGETED[ass])
+            if ass in var.PLAYERS and not is_user_simple(ass):
+                message += " If you die you will take out your target with you."
+            pm(cli, ass, message)
         else:
-            pm(cli, ass, "You are an \u0002assassin\u0002.")
-        pm(cli, ass, "Players: " + ", ".join(pl))
+            if ass in var.PLAYERS and not is_user_simple(ass):
+                pm(cli, ass, ('You are an \u0002assassin\u0002. Choose a target with ' +
+                              '"target <nick>". If you die you will take out your target with you. ' +
+                              'If your target dies you may choose another one.'))
+            else:
+                pm(cli, ass, "You are an \u0002assassin\u0002.")
+            pm(cli, ass, "Players: " + ", ".join(pl))
 
     if var.FIRST_NIGHT:
         for mm in var.ROLES["matchmaker"]:

--- a/settings/wolfgame.py
+++ b/settings/wolfgame.py
@@ -199,7 +199,7 @@ TEMPLATE_RESTRICTIONS = {"cursed villager" : WOLF_ROLES + ["seer", "oracle", "au
                          "gunner"          : WOLFTEAM_ROLES + ["fool", "lycan", "jester"],
                          "sharpshooter"    : WOLFTEAM_ROLES + ["fool", "lycan", "jester"],
                          "mayor"           : ["fool", "jester", "monster"],
-                         "assassin"        : WOLF_ROLES + list(TOTEM_ORDER) + ["traitor", "seer", "augur", "oracle", "harlot", "detective", "bodyguard", "guardian angel", "village drunk", "hunter", "fool", "mayor", "lycan", "doctor"],
+                         "assassin"        : WOLF_ROLES + ["traitor", "seer", "augur", "oracle", "harlot", "detective", "bodyguard", "guardian angel", "lycan"],
                          "bureaucrat"      : [],
                          }
 


### PR DESCRIPTION
The only roles that should NOT be assassin are roles that the other team
MUST kill in order to have a good shot at winning. Therefore, we don't
need to have so many saferoles unable to be assassin, as well as certain
neutral roles. The current list is as follows:

- wolves + traitor, since these all need to die for village to win
- lycan, because if turned they need to die for village to win
- seer/oracle/harlot/augur/detective, capable of making safes so wolves
  need to focus on killing them in order to have a shot at winning
- bodyguard/GA, capable of preventing other safes from dying, again need
  to die for wolves to have a shot at winning

Everyone else is fair game, including shaman, drunk, hunter, doctor,
crazed shaman, and fool (who were all previously restricted).

If drunk is assassin, they don't get to choose their target, rather they
get one randomly assigned to them automatically.