### PR TITLE
fsync command

### DIFF
--- a/modules/wolfgame.py
+++ b/modules/wolfgame.py
@@ -367,6 +367,26 @@ def make_stasis(nick, penalty):
         var.STASISED[cloak] += penalty
         var.set_stasis(cloak, var.STASISED[cloak])
 
+@cmd("fsync", admin_only=True, pm=True)
+def fsync(cli, nick, chan, rest):
+    """Makes the bot apply the currently appropriate channel modes."""
+    sync_modes(cli)
+
+def sync_modes(cli):
+    voices = []
+    pl = var.list_players()
+    for nick, u in var.USERS.items():
+        if nick in pl and 'v' not in u.get('modes', set()):
+            voices.append(("+v", nick))
+        elif nick not in pl and 'v' in u.get('modes', set()):
+            voices.append(("-v", nick))
+    if var.PHASE in ("day", "night"):
+        other = ["+m"]
+    else:
+        other = ["-m"]
+
+    mass_mode(cli, voices, other)
+
 @cmd("fdie", "fbye", admin_only=True, pm=True)
 def forced_exit(cli, nick, chan, rest):  # Admin Only
     """Forces the bot to close."""

--- a/modules/wolfgame.py
+++ b/modules/wolfgame.py
@@ -228,6 +228,12 @@ def check_for_modes(cli, rnick, chan, modeaction, *target):
                     var.USERS[trgt]["moded"].remove(change)
             elif change in var.USERS[trgt]["modes"]:
                 var.USERS[trgt]["modes"].remove(change)
+    # Only sync modes if a server changed modes because
+    # 1) human ops probably know better
+    # 2) other bots might start a fight over modes
+    # 3) recursion; we see our own mode changes.
+    if "!" not in rnick:
+        sync_modes(cli)
 
 #completes a partial nickname or string from a list
 def complete_match(string, matches):

--- a/modules/wolfgame.py
+++ b/modules/wolfgame.py
@@ -265,13 +265,13 @@ def get_victim(cli, nick, victim, self_in_list = False):
 def mass_mode(cli, md):
     """ Example: mass_mode(cli, (('+v', 'asdf'), ('-v','wobosd'))) """
     lmd = len(md)  # store how many mode changes to do
-    for start_i in range(0, lmd, 4):  # 4 mode-changes at a time
-        if start_i + 4 > lmd:  # If this is a remainder (mode-changes < 4)
+    for start_i in range(0, lmd, var.MODELIMIT):  # 4 mode-changes at a time
+        if start_i + var.MODELIMIT > lmd:  # If this is a remainder (mode-changes < 4)
             z = list(zip(*md[start_i:]))  # zip this remainder
-            ei = lmd % 4  # len(z)
+            ei = lmd % var.MODELIMIT  # len(z)
         else:
-            z = list(zip(*md[start_i:start_i+4])) # zip four
-            ei = 4 # len(z)
+            z = list(zip(*md[start_i:start_i+var.MODELIMIT])) # zip four
+            ei = var.MODELIMIT # len(z)
         # Now z equal something like [('+v', '-v'), ('asdf', 'wobosd')]
         arg1 = "".join(z[0])
         arg2 = " ".join(z[1])  # + " " + " ".join([x+"!*@*" for x in z[1]])
@@ -4547,6 +4547,11 @@ def getfeatures(cli, nick, *rest):
         if r.startswith("CHANMODES="):
             chans = r[10:].split(",")
             var.LISTMODES, var.MODES_ALLSET, var.MODES_ONLYSET, var.MODES_NOSET = chans
+        if r.startswith("MODES="):
+            try:
+                var.MODELIMIT = int(r[6:])
+            except ValueError:
+                pass
 
 def mass_privmsg(cli, targets, msg, notice=False, privmsg=False):
     if not notice and not privmsg:

--- a/modules/wolfgame.py
+++ b/modules/wolfgame.py
@@ -194,40 +194,39 @@ def check_for_modes(cli, rnick, chan, modeaction, *target):
     trgt = ""
     keeptrg = False
     target = list(target)
-    if not target or target == [botconfig.NICK]:
-        return
-    while modeaction:
-        if len(modeaction) > 1:
-            prefix = modeaction[0]
-            change = modeaction[1]
-        else:
-            prefix = oldpref
-            change = modeaction[0]
-        if not keeptrg:
-            if target:
-                trgt = target.pop(0)
+    if target and target != [botconfig.NICK]:
+        while modeaction:
+            if len(modeaction) > 1:
+                prefix = modeaction[0]
+                change = modeaction[1]
             else:
-                trgt = "" # Last item, no target
-        keeptrg = False
-        if not prefix in ("-", "+"):
-            change = prefix
-            prefix = oldpref
-        else:
-            oldpref = prefix
-        modeaction = modeaction[modeaction.index(change)+1:]
-        if change in var.MODES_NOSET:
-            keeptrg = True
-        if prefix == "-" and change in var.MODES_ONLYSET:
-            keeptrg = True
-        if change not in var.MODES_PREFIXES.values():
-            continue
-        if trgt in var.USERS:
-            if prefix == "+":
-                var.USERS[trgt]["modes"].add(change)
-                if change in var.USERS[trgt]["moded"]:
-                    var.USERS[trgt]["moded"].remove(change)
-            elif change in var.USERS[trgt]["modes"]:
-                var.USERS[trgt]["modes"].remove(change)
+                prefix = oldpref
+                change = modeaction[0]
+            if not keeptrg:
+                if target:
+                    trgt = target.pop(0)
+                else:
+                    trgt = "" # Last item, no target
+            keeptrg = False
+            if not prefix in ("-", "+"):
+                change = prefix
+                prefix = oldpref
+            else:
+                oldpref = prefix
+            modeaction = modeaction[modeaction.index(change)+1:]
+            if change in var.MODES_NOSET:
+                keeptrg = True
+            if prefix == "-" and change in var.MODES_ONLYSET:
+                keeptrg = True
+            if change not in var.MODES_PREFIXES.values():
+                continue
+            if trgt in var.USERS:
+                if prefix == "+":
+                    var.USERS[trgt]["modes"].add(change)
+                    if change in var.USERS[trgt]["moded"]:
+                        var.USERS[trgt]["moded"].remove(change)
+                elif change in var.USERS[trgt]["modes"]:
+                    var.USERS[trgt]["modes"].remove(change)
     # Only sync modes if a server changed modes because
     # 1) human ops probably know better
     # 2) other bots might start a fight over modes

--- a/settings/wolfgame.py
+++ b/settings/wolfgame.py
@@ -43,6 +43,8 @@ ACC_GRACE_TIME = 30
 START_QUIT_DELAY = 10
 #  controls how many people it does in one /msg; only works for messages that are the same
 MAX_PRIVMSG_TARGETS = 4
+# how many mode values can be specified at once; used only as fallback
+MODELIMIT = 3
 LEAVE_STASIS_PENALTY = 1
 IDLE_STASIS_PENALTY = 1
 PART_STASIS_PENALTY = 1


### PR DESCRIPTION
Allows ops to easily synchronize the actual channel modes with the bot's view of what they should be. Could be easily extended to call this automatically when servers reset modes on netjoin; I'll look into that tomorrow.