### PR TITLE
Add the new ping-if feature.

### DIFF
--- a/modules/wolfgame.py
+++ b/modules/wolfgame.py
@@ -800,7 +800,7 @@ def fpinger(cli, nick, chan, rest):
 
 @cmd("pingif", "pingme", "pingat", "pingpref", "ping-if", pm=True)
 def altpinger(cli, nick, chan, rest):
-    """Pings you when the number of players reaches your preference."""
+    """Pings you when the number of players reaches your preference. Usage: 'pingif <players> [once|ping|always]'"""
     altpinged, players = is_user_altpinged(nick)
     rest = rest.split()
     if nick in var.USERS:
@@ -912,7 +912,7 @@ def altpinger(cli, nick, chan, rest):
                 var.PING_PREFS[cloak] = "all"
                 var.set_ping_pref(cloak, "all")
         else:
-            msg.append("Unrecognized preference.")
+            msg.append("Invalid parameter. Please enter a non-negative integer or a valid preference.")
 
     if chan == nick:
         pm(cli, nick, "\n".join(msg).format(botconfig.CMD_CHAR))

--- a/modules/wolfgame.py
+++ b/modules/wolfgame.py
@@ -483,11 +483,11 @@ def pinger(cli, nick, chan, rest):
             acc = var.USERS[user]["account"]
             if not is_user_away(user):
                 TO_PING.append(user)
-            elif (acc != "*" and acc in var.PING_IF_PREFS_ACCS and var.PING_IF_PREFS_ACCS[acc] <= len(pl)
-                  and acc in var.PING_PREFS_ACCS and var.PING_PREFS_ACCS[acc] in ("ping", "all")):
+            elif (acc != "*" and var.PING_IF_PREFS_ACCS.get(acc, 999) <= len(pl)
+                  and var.PING_PREFS_ACCS.get(acc) in ("ping", "all")):
                 TO_PING.append(user)
-            elif (not var.ACCOUNTS_ONLY and cloak in var.PING_IF_PREFS and var.PING_IF_PREFS[cloak] <= len(pl)
-                  and cloak in var.PING_PREFS and var.PING_PREFS[cloak] in ("ping", "all")):
+            elif (not var.ACCOUNTS_ONLY and var.PING_IF_PREFS.get(cloak, 999) <= len(pl)
+                  and var.PING_PREFS.get(cloak) in ("ping", "all")):
                 TO_PING.append(user)
 
     @hook("endofwho", hookid=800)
@@ -872,13 +872,13 @@ def altpinger(cli, nick, chan, rest):
         with var.WARNING_LOCK:
             if pref.lower() in ("once", "one", "first", "onjoin"):
                 if acc and acc != "*":
-                    if acc in var.PING_PREFS_ACCS.keys() and var.PING_PREFS_ACCS[acc] == "once":
+                    if var.PING_PREFS_ACCS.get(acc) == "once":
                         msg.append("You are already set to be pinged once when your desired player count is reached.")
                     else:
                         msg.append("You will now get pinged once when your preferred amount of players is reached.")
                         var.PING_PREFS_ACCS[acc] = "once"
                         var.set_ping_pref_acc(acc, "once")
-                elif cloak in var.PING_PREFS.keys() and var.PING_PREFS[cloak] == "once":
+                elif var.PING_PREFS.get(cloak) == "once":
                     msg.append("You are already set to be pinged once when your desired player count is reached.")
                 else:
                     msg.append("You will now get pinged once when your preferred amount of players is reached.")
@@ -887,13 +887,13 @@ def altpinger(cli, nick, chan, rest):
 
             elif pref.lower() in ("ondemand", "ping", botconfig.CMD_CHAR + "ping"):
                 if acc and acc != "*":
-                    if acc in var.PING_PREFS_ACCS.keys() and var.PING_PREFS_ACCS[acc] == "ping":
+                    if var.PING_PREFS_ACCS.get(acc) == "ping":
                         msg.append("You are already set to be added to the {0}ping list when enough players have joined.")
                     else:
                         msg.append("You will now be added to the {0}ping list when enough players have joined.")
                         var.PING_PREFS_ACCS[acc] = "ping"
                         var.set_ping_pref_acc(acc, "ping")
-                elif cloak in var.PING_PREFS.keys() and var.PING_PREFS[cloak] == "ping":
+                elif var.PING_PREFS.get(cloak) == "ping":
                     msg.append("You are already set to be added to the {0}ping list when enough players have joined.")
                 else:
                     msg.append("You will now be added to the {0}ping list when enough players have joined.")
@@ -902,13 +902,13 @@ def altpinger(cli, nick, chan, rest):
 
             elif pref.lower() in ("all", "always"):
                 if acc and acc != "*":
-                    if acc in var.PING_PREFS_ACCS.keys() and var.PING_PREFS_ACCS[acc] == "all":
+                    if var.PING_PREFS_ACCS.get(acc) == "all":
                         msg.append("You are already set to be added to the {0}ping list as well as being pinged immediately when enough players have joined.")
                     else:
                         msg.append("You will now be added to the {0}ping list as well as being pinged immediately when your preferred amount of players is reached.")
                         var.PING_PREFS_ACCS[acc] = "all"
                         var.set_ping_pref_acc(acc, "all")
-                elif cloak in var.PING_PREFS.keys() and var.PING_PREFS[cloak] == "all":
+                elif var.PING_PREFS.get(cloak) == "all":
                     msg.append("You are already set to be added to the {0}ping list as well as being pinged immediately when enough players have joined.")
                 else:
                     msg.append("You will now be added to the {0}ping list as well as being pinged immediately when your preferred amount of players is reached.")
@@ -1028,11 +1028,11 @@ def join_timer_handler(cli):
                 return
 
             if acc and acc != "*":
-                if acc in chk_acc and acc in var.PING_PREFS_ACCS and var.PING_PREFS_ACCS[acc] in ("once", "all"):
+                if acc in chk_acc and var.PING_PREFS_ACCS.get(acc) in ("once", "all"):
                     to_ping.append(user)
                     var.PINGED_ALREADY_ACCS.append(acc)
 
-            elif not var.ACCOUNTS_ONLY and cloak in checker and cloak in var.PING_PREFS and var.PING_PREFS[cloak] in ("once", "all"):
+            elif not var.ACCOUNTS_ONLY and cloak in checker and var.PING_PREFS.get(cloak) in ("once", "all"):
                 to_ping.append(user)
                 var.PINGED_ALREADY.append(cloak)
 

--- a/modules/wolfgame.py
+++ b/modules/wolfgame.py
@@ -826,8 +826,8 @@ def altpinger(cli, nick, chan, rest):
 
     msg = []
     pref_mean = {"once": "pinged immediately",
-                 "ping": "added automatically to the {0}ping list",
-                 "all" : "pinged immediately and added to the {0}ping list"}
+                 "ping": "added automatically to the ping list",
+                 "all" : "pinged immediately and added to the ping list"}
 
     if not rest:
         if altpinged:

--- a/modules/wolfgame.py
+++ b/modules/wolfgame.py
@@ -888,30 +888,30 @@ def altpinger(cli, nick, chan, rest):
             elif pref.lower() in ("ondemand", "ping", botconfig.CMD_CHAR + "ping"):
                 if acc and acc != "*":
                     if var.PING_PREFS_ACCS.get(acc) == "ping":
-                        msg.append("You are already set to be added to the {0}ping list when enough players have joined.")
+                        msg.append("You are already set to be added to the ping list when enough players have joined.")
                     else:
-                        msg.append("You will now be added to the {0}ping list when enough players have joined.")
+                        msg.append("You will now be added to the ping list when enough players have joined.")
                         var.PING_PREFS_ACCS[acc] = "ping"
                         var.set_ping_pref_acc(acc, "ping")
                 elif var.PING_PREFS.get(cloak) == "ping":
-                    msg.append("You are already set to be added to the {0}ping list when enough players have joined.")
+                    msg.append("You are already set to be added to the ping list when enough players have joined.")
                 else:
-                    msg.append("You will now be added to the {0}ping list when enough players have joined.")
+                    msg.append("You will now be added to the ping list when enough players have joined.")
                     var.PING_PREFS[cloak] = "ping"
                     var.set_ping_pref(cloak, "ping")
 
             elif pref.lower() in ("all", "always"):
                 if acc and acc != "*":
                     if var.PING_PREFS_ACCS.get(acc) == "all":
-                        msg.append("You are already set to be added to the {0}ping list as well as being pinged immediately when enough players have joined.")
+                        msg.append("You are already set to be added to the ping list as well as being pinged immediately when enough players have joined.")
                     else:
-                        msg.append("You will now be added to the {0}ping list as well as being pinged immediately when your preferred amount of players is reached.")
+                        msg.append("You will now be added to the ping list as well as being pinged immediately when your preferred amount of players is reached.")
                         var.PING_PREFS_ACCS[acc] = "all"
                         var.set_ping_pref_acc(acc, "all")
                 elif var.PING_PREFS.get(cloak) == "all":
-                    msg.append("You are already set to be added to the {0}ping list as well as being pinged immediately when enough players have joined.")
+                    msg.append("You are already set to be added to the ping list as well as being pinged immediately when enough players have joined.")
                 else:
-                    msg.append("You will now be added to the {0}ping list as well as being pinged immediately when your preferred amount of players is reached.")
+                    msg.append("You will now be added to the ping list as well as being pinged immediately when your preferred amount of players is reached.")
                     var.PING_PREFS[cloak] = "all"
                     var.set_ping_pref(cloak, "all")
 
@@ -919,9 +919,9 @@ def altpinger(cli, nick, chan, rest):
                 msg.append("Invalid parameter. Please enter a non-negative integer or a valid preference.")
 
     if chan == nick:
-        pm(cli, nick, "\n".join(msg).format(botconfig.CMD_CHAR))
+        pm(cli, nick, "\n".join(msg))
     else:
-        cli.notice(nick, "\n".join(msg).format(botconfig.CMD_CHAR))
+        cli.notice(nick, "\n".join(msg))
 
 def is_user_altpinged(nick):
     if nick in var.USERS.keys():

--- a/modules/wolfgame.py
+++ b/modules/wolfgame.py
@@ -837,8 +837,6 @@ def altpinger(cli, nick, chan, rest):
         if altpinged:
             msg.append("Your ping preferences have been removed (was {0}).".format(players))
             toggle_altpinged_status(nick, 0, players)
-        elif not rest:
-            msg.append("You need to enter a number.")
         else:
             msg.append("You do not have any preferences set.")
 

--- a/settings/wolfgame.py
+++ b/settings/wolfgame.py
@@ -252,6 +252,9 @@ PING_IF_PREFS_ACCS = {}
 PING_IF_NUMS = {}
 PING_IF_NUMS_ACCS = {}
 
+PING_PREFS = {}
+PING_PREFS_ACCS = {}
+
 is_role = lambda plyr, rol: rol in ROLES and plyr in ROLES[rol]
 
 def is_admin(nick, cloak=None, acc=None):
@@ -805,6 +808,10 @@ def init_db():
 
         c.execute('CREATE TABLE IF NOT EXISTS ping_if_prefs_accs (acc TEXT, players INTEGER)') # ping-if prefs (accounts - primary)
 
+        c.execute('CREATE TABLE IF NOT EXISTS ping_prefs (cloak TEXT, pref TEXT)') # ping-if preferences (none = only in !ping; all = on join and in !ping)
+
+        c.execute('CREATE TABLE IF NOT EXISTS ping_prefs_accs (acc TEXT, pref TEXT)') # ping-if prefs (accounts - primary)
+
         c.execute('SELECT * FROM away')
         for row in c:
             AWAY.append(row[0])
@@ -876,6 +883,14 @@ def init_db():
             if row[1] not in PING_IF_NUMS_ACCS:
                 PING_IF_NUMS_ACCS[row[1]] = []
             PING_IF_NUMS_ACCS[row[1]].append(row[0])
+
+        c.execute('SELECT * FROM ping_prefs')
+        for row in c:
+            PING_PREFS[row[0]] = row[1]
+
+        c.execute('SELECT * FROM ping_prefs_accs')
+        for row in c:
+            PING_PREFS_ACCS[row[0]] = row[1]
 
         # populate the roles table
         c.execute('DROP TABLE IF EXISTS roles')
@@ -1018,17 +1033,23 @@ def remove_allow_acc(acc, command):
 
 def set_ping_if_status(cloak, players):
     with conn:
-        if players == 0:
-            c.execute('DELETE FROM ping_if_prefs WHERE cloak=?', (cloak,))
-        else:
+        c.execute('DELETE FROM ping_if_prefs WHERE cloak=?', (cloak,))
+        if players != 0:
             c.execute('INSERT OR REPLACE INTO ping_if_prefs VALUES (?,?)', (cloak, players))
 
 def set_ping_if_status_acc(acc, players):
     with conn:
-        if players == 0:
-            c.execute('DELETE FROM ping_if_prefs_accs WHERE acc=?', (acc,))
-        else:
+        c.execute('DELETE FROM ping_if_prefs_accs WHERE acc=?', (acc,))
+        if players != 0:
             c.execute('INSERT OR REPLACE INTO ping_if_prefs_accs VALUES (?,?)', (acc, players))
+
+def set_ping_pref(cloak, pref):
+    with conn:
+        c.execute('INSERT OR REPLACE INTO ping_prefs VALUES (?,?)', (cloak, pref))
+
+def set_ping_pref_acc(acc, pref):
+    with conn:
+        c.execute('INSERT OR REPLACE INTO ping_prefs_accs VALUES (?,?)', (acc, pref))
 
 def update_role_stats(acc, role, won, iwon):
     with conn:


### PR DESCRIPTION
This adds a `!pingif` (and a few aliases, such as `!pingat` and `!pingme`) command to lykos. People who pick this option will see themselves added to the !ping list, regardless of their !away status, when the amount of players reaches or exceeds their preferences. `!pingif` can also be used to set how they want to be pinged (either right away when the sufficient amount of players have joined, added to the ping list but not pinged, or both). The bot will ping all players it can roughly 10 seconds after the last !join; this is done to reduce unnecessary who requests and pingspamming, which could cause both lag and annoyance. This is done through a separate thread, started when the first player joins, which exits when the game starts or the last player quits.

This is pretty much ready to merge, awaiting some feedback. I don't think there's anything else left to add or change, I think I've managed to please everyone with this.

Edit: This references #43 and sort of fills its purpose. It pings you instead of joining you, and does pretty much everything in a much saner way.