### PR TITLE
Change decorators

### DIFF
--- a/src/decorators.py
+++ b/src/decorators.py
@@ -111,6 +111,24 @@ class cmd:
 
             return self.func(*largs) # don't check restrictions for role commands
 
+        if self.owner_only:
+            if var.is_owner(nick, cloak):
+                adminlog(chan, rawnick, self.name, rest)
+                return self.func(*largs)
+
+            if chan == nick:
+                pm(cli, nick, "You are not the owner.")
+            else:
+                cli.notice(nick, "You are not the owner.")
+            return
+
+        if not self.admin_only:
+            return self.func(*largs)
+
+        if var.is_admin(nick, cloak):
+            adminlog(chan, rawnick, self.name, rest)
+            return self.func(*largs)
+
         if acc:
             for pattern in var.DENY_ACCOUNTS:
                 if fnmatch.fnmatch(acc.lower(), pattern.lower()):
@@ -126,8 +144,7 @@ class cmd:
                 if fnmatch.fnmatch(acc.lower(), pattern.lower()):
                     for command in self.cmds:
                         if command in var.ALLOW_ACCOUNTS[pattern]:
-                            if self.admin_only or self.owner_only:
-                                adminlog(chan, rawnick, self.name, rest)
+                            adminlog(chan, rawnick, self.name, rest)
                             return self.func(*largs)
 
         if not var.ACCOUNTS_ONLY and cloak:
@@ -145,33 +162,14 @@ class cmd:
                 if fnmatch.fnmatch(cloak.lower(), pattern.lower()):
                     for command in self.cmds:
                         if command in var.ALLOW[pattern]:
-                            if self.admin_only or self.owner_only:
-                                adminlog(chan, rawnick, self.name, rest)
+                            adminlog(chan, rawnick, self.name, rest)
                             return self.func(*largs)
 
-        if self.owner_only:
-            if var.is_owner(nick, cloak):
-                adminlog(chan, rawnick, self.name, rest)
-                return self.func(*largs)
-
-            if chan == nick:
-                pm(cli, nick, "You are not the owner.")
-            else:
-                cli.notice(nick, "You are not the owner.")
-            return
-
-        if self.admin_only:
-            if var.is_admin(nick, cloak):
-                adminlog(chan, rawnick, self.name, rest)
-                return self.func(*largs)
-
-            if chan == nick:
-                pm(cli, nick, "You are not an admin.")
-            else:
-                cli.notice(nick, "You are not an admin.")
-            return
-
-        return self.func(*largs)
+        if chan == nick:
+            pm(cli, nick, "You are not an admin.")
+        else:
+            cli.notice(nick, "You are not an admin.")
+        return
 
 class hook:
     def __init__(self, name, hookid=-1):

--- a/src/decorators.py
+++ b/src/decorators.py
@@ -181,9 +181,6 @@ class hook:
         self.__doc__ = self.func.__doc__
         return self
 
-    def caller(self, *args):
-        return self.func(*args)
-
     @staticmethod
     def unhook(hookid):
         for each in list(HOOKS):

--- a/src/decorators.py
+++ b/src/decorators.py
@@ -59,9 +59,6 @@ class cmd:
         if not self.raw_nick:
             largs[1] = nick
 
-        if nick == "<console>":
-            return self.func(*largs) # special case; no questions
-
         if not self.pm and chan == nick:
             return # PM command, not allowed
 

--- a/src/decorators.py
+++ b/src/decorators.py
@@ -1,6 +1,3 @@
-# Old, obsolete & original code by jcao219
-# rewritten by Vgr
-
 import fnmatch
 from collections import defaultdict
 
@@ -46,12 +43,12 @@ class cmd:
                 self.aliases.append(self)
             alias = True
 
-    def __call__(self, *args):
-        if self.func is None: # when function is defined; set self.func and call itself again
-            self.func = args[0]
-            self.__doc__ = self.func.__doc__
-            return self
+    def __call__(self, func):
+        self.func = func
+        self.__doc__ = self.func.__doc__
+        return self
 
+    def caller(self, *args):
         largs = list(args)
 
         cli, rawnick, chan, rest = largs
@@ -205,11 +202,12 @@ class hook:
 
         HOOKS[name].append(self)
 
-    def __call__(self, *args):
-        if self.func is None:
-            self.func = args[0]
-            self.__doc__ = self.func.__doc__
-            return self
+    def __call__(self, func):
+        self.func = func
+        self.__doc__ = self.func.__doc__
+        return self
+
+    def caller(self, *args):
         return self.func(*args)
 
     @staticmethod

--- a/src/handler.py
+++ b/src/handler.py
@@ -59,7 +59,7 @@ def on_privmsg(cli, rawnick, chan, msg, notice = False):
 
     for fn in decorators.COMMANDS[""]:
         try:
-            fn(cli, rawnick, chan, msg)
+            fn.caller(cli, rawnick, chan, msg)
         except Exception:
             if botconfig.DEBUG_MODE:
                 raise
@@ -79,7 +79,7 @@ def on_privmsg(cli, rawnick, chan, msg, notice = False):
         if not h or h[0] == " ":
             for fn in decorators.COMMANDS.get(x, []):
                 try:
-                    fn(cli, rawnick, chan, h.lstrip())
+                    fn.caller(cli, rawnick, chan, h.lstrip())
                 except Exception:
                     if botconfig.DEBUG_MODE:
                         raise
@@ -94,7 +94,7 @@ def unhandled(cli, prefix, cmd, *args):
             if isinstance(arg, bytes): largs[i] = arg.decode('ascii')
         for fn in decorators.HOOKS.get(cmd, []):
             try:
-                fn(cli, prefix, *largs)
+                fn.caller(cli, prefix, *largs)
             except Exception as e:
                 if botconfig.DEBUG_MODE:
                     raise e

--- a/src/handler.py
+++ b/src/handler.py
@@ -94,7 +94,7 @@ def unhandled(cli, prefix, cmd, *args):
             if isinstance(arg, bytes): largs[i] = arg.decode('ascii')
         for fn in decorators.HOOKS.get(cmd, []):
             try:
-                fn.caller(cli, prefix, *largs)
+                fn.func(cli, prefix, *largs)
             except Exception as e:
                 if botconfig.DEBUG_MODE:
                     raise e

--- a/src/wolfgame.py
+++ b/src/wolfgame.py
@@ -5676,7 +5676,7 @@ def cgamemode(cli, arg):
 
 
 @cmd("start", phases=("join",))
-def fstart(cli, nick, chan, rest):
+def start_cmd(cli, nick, chan, rest):
     """Starts a game of Werewolf."""
     start(cli, nick, chan)
 

--- a/src/wolfgame.py
+++ b/src/wolfgame.py
@@ -49,14 +49,12 @@ debuglog = logger("debug.log", write=False, display=False) # will be True if in 
 errlog = logger("errors.log")
 plog = logger(None) #use this instead of print so that logs have timestamps
 
-COMMANDS = {}
-HOOKS = {}
-
 is_admin = var.is_admin
 is_owner = var.is_owner
 
-cmd = decorators.generate(COMMANDS)
-hook = decorators.generate(HOOKS, raw_nick=True, permissions=False)
+cmd = decorators.cmd
+hook = decorators.hook
+COMMANDS = decorators.COMMANDS
 
 # Game Logic Begins:
 
@@ -228,7 +226,7 @@ def connect_callback(cli):
             notify_error(cli, botconfig.CHANNEL, errlog)
 
         # Unhook the WHO hooks
-        decorators.unhook(HOOKS, 295)
+        hook.unhook(295)
 
 
     #bot can be tricked into thinking it's still opped by doing multiple modes at once
@@ -377,6 +375,8 @@ def pm(cli, target, message):  # message either privmsg or notice, depending on 
         return
 
     cli.msg(target, message)
+
+decorators.pm = pm
 
 def reset_settings():
     var.CURRENT_GAMEMODE.teardown()
@@ -898,7 +898,7 @@ def join_timer_handler(cli):
             # I was lucky to catch this in testing, as it requires precise timing
             # it only failed if a join happened while this outer func had started
             var.PINGING_IFS = False
-            decorators.unhook(HOOKS, 387)
+            hook.unhook(387)
             if to_ping:
                 to_ping.sort(key=lambda x: x.lower())
 
@@ -6703,7 +6703,7 @@ def show_admins(cli, nick, chan, rest):
         else:
             cli.msg(chan, msg)
 
-        decorators.unhook(HOOKS, 4)
+        hook.unhook(4)
         var.ADMIN_PINGING = False
 
     if nick == chan:


### PR DESCRIPTION
Old decorators were silly and stupid, and we certainly did not need a generator for these. Moreover, it was a bunch of intrinsic namespace mangling, which we try to avoid as much as possible. I change those to be classes, so this means they are more customizable and less namespace-mangled-restricted-whatever. This works fine, waiting on other people's suggestions.