### PR TITLE
Fix voicing on rejoin at night when devoice during night is enabled

### DIFF
--- a/src/wolfgame.py
+++ b/src/wolfgame.py
@@ -3310,7 +3310,8 @@ def on_join(cli, raw_nick, chan, acc="*", rname=""):
             hm = var.DISCONNECTED[nick][1]
             act = var.DISCONNECTED[nick][0]
             if (acc == act and not var.DISABLE_ACCOUNTS) or (hostmask == hm and not var.ACCOUNTS_ONLY):
-                cli.mode(chan, "+v", nick, nick+"!*@*")
+                if not var.DEVOICE_DURING_NIGHT or var.PHASE != "night":
+                    cli.mode(chan, "+v", nick, nick+"!*@*")
                 del var.DISCONNECTED[nick]
                 var.LAST_SAID_TIME[nick] = datetime.now()
                 cli.msg(chan, messages["player_return"].format(nick))


### PR DESCRIPTION
When players part and rejoin during the night phase when `DEVOICE_DURING_NIGHT = True` the bot revoices them. This fixes that.