### PR TITLE
Revert "Support IPv6 connections"

### DIFF
--- a/oyoyo/client.py
+++ b/oyoyo/client.py
@@ -21,7 +21,6 @@ import sys
 import threading
 import time
 import traceback
-import os
 
 from oyoyo.parse import parse_raw_irc_command
 
@@ -100,7 +99,7 @@ class IRCClient(object):
         To enable blocking pass blocking=True.
         """
 
-        self.socket = None
+        self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self.nickname = ""
         self.hostmask = ""
         self.ident = ""
@@ -178,14 +177,13 @@ class IRCClient(object):
             retries = 0
             while True:
                 try:
-                    self.socket = socket.create_connection(("{0}".format(self.host), self.port))
+                    self.socket.connect(("{0}".format(self.host), self.port))
                     break
                 except socket.error as e:
                     retries += 1
                     self.stream_handler('Error: {0}'.format(e), level="warning")
                     if retries > 3:
-                        exit(os.EX_UNAVAILABLE)
-
+                        break
             if not self.blocking:
                 self.socket.setblocking(0)
 


### PR DESCRIPTION
Reverts lykoss/lykos#204

[2015-12-05 00:47:01+0000] Traceback (most recent call last):
  File "./wolfbot.py", line 71, in <module>
    main()
  File "./wolfbot.py", line 64, in main
    stream_handler=src.stream,
  File "/home/lykos/lykos/oyoyo/client.py", line 126, in __init__
    self.socket = ssl.wrap_socket(self.socket)
  File "/usr/lib/python3.4/ssl.py", line 887, in wrap_socket
    ciphers=ciphers)
  File "/usr/lib/python3.4/ssl.py", line 525, in __init__
    if sock.getsockopt(SOL_SOCKET, SO_TYPE) != SOCK_STREAM:
AttributeError: 'NoneType' object has no attribute 'getsockopt'
