### PR TITLE
Fix first night message

### DIFF
--- a/src/wolfgame.py
+++ b/src/wolfgame.py
@@ -7196,7 +7196,7 @@ def transition_night(cli):
 
     dmsg = (daydur_msg + messages["night_begin"])
 
-    if not var.FIRST_NIGHT:
+    if var.FIRST_NIGHT:
         dmsg = (dmsg + messages["first_night_begin"])
     cli.msg(chan, dmsg)
     debuglog("BEGIN NIGHT")


### PR DESCRIPTION
This got mixed up in the whole move of the messages to an external file. Right now it always prints the first night message («… If you did not receive one, simply sit back, relax, and wait patiently for morning.») on every night _except_ for the first night. This reverts it to the proper behaviour.