### PR TITLE
Notify players in deadchat when the game ends

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -178,6 +178,7 @@
     "traitor_turn_channel": "\u0002The villagers, during their celebrations, are frightened as they hear a loud howl. The wolves are not gone!\u0002",
     "role_attribution_failed": "The role attribution failed 3 times. Game was canceled.",
     "endgame_stats": "Game lasted \u0002{0:0>2}:{1:0>2}\u0002. \u0002{2:0>2}:{3:0>2}\u0002 was day. \u0002{4:0>2}:{5:0>2}\u0002 was night. ",
+    "endgame_deadchat": "The game has ended, check {0} for the results.",
     "single_winner": "The winner is \u0002{0}\u0002.",
     "two_winners": "The winners are \u0002{0}\u0002 and \u0002{1}\u0002.",
     "many_winners": "The winners are {0}, and \u0002{1}\u0002.",

--- a/src/wolfgame.py
+++ b/src/wolfgame.py
@@ -2440,8 +2440,6 @@ def stop_game(cli, winner = "", abort = False, additional_winners = None):
 
     if not abort:
         cli.msg(chan, gameend_msg)
-        # Message Players in Deadchat letting them know that the game has ended. cyberfawkes
-        mass_privmsg(cli, var.DEADCHAT_PLAYERS, messages["endgame_deadchat"].format(chan))
         
     roles_msg = []
 
@@ -2665,6 +2663,9 @@ def stop_game(cli, winner = "", abort = False, additional_winners = None):
         elif len(winners) > 2:
             nicklist = ("\u0002" + x + "\u0002" for x in winners[0:-1])
             cli.msg(chan, messages["many_winners"].format(", ".join(nicklist), winners[-1]))
+
+    # Message Players in Deadchat letting them know that the game has ended.
+    mass_privmsg(cli, var.DEADCHAT_PLAYERS, messages["endgame_deadchat"].format(chan))
 
     reset_modes_timers(cli)
 

--- a/src/wolfgame.py
+++ b/src/wolfgame.py
@@ -2440,7 +2440,7 @@ def stop_game(cli, winner = "", abort = False, additional_winners = None):
 
     if not abort:
         cli.msg(chan, gameend_msg)
-        #cyberfawkes addition
+        # Message Players in Deadchat letting them know that the game has ended. cyberfawkes
         mass_privmsg(cli, var.DEADCHAT_PLAYERS, messages["endgame_deadchat"].format(chan))
         
     roles_msg = []

--- a/src/wolfgame.py
+++ b/src/wolfgame.py
@@ -2440,7 +2440,9 @@ def stop_game(cli, winner = "", abort = False, additional_winners = None):
 
     if not abort:
         cli.msg(chan, gameend_msg)
-
+        #cyberfawkes addition
+        mass_privmsg(cli, var.DEADCHAT_PLAYERS, messages["endgame_deadchat"].format(chan))
+        
     roles_msg = []
 
     origroles = {} #nick based list of original roles

--- a/src/wolfgame.py
+++ b/src/wolfgame.py
@@ -2440,7 +2440,7 @@ def stop_game(cli, winner = "", abort = False, additional_winners = None):
 
     if not abort:
         cli.msg(chan, gameend_msg)
-        
+
     roles_msg = []
 
     origroles = {} #nick based list of original roles


### PR DESCRIPTION
Added a PM to inform Deadchat Players that the game has ended.