### PR TITLE
Split mayor

### DIFF
--- a/src/roles/mayor.py
+++ b/src/roles/mayor.py
@@ -1,0 +1,37 @@
+import re
+import random
+import itertools
+import math
+from collections import defaultdict
+
+import botconfig
+import src.settings as var
+from src.utilities import *
+from src import debuglog, errlog, plog
+from src.decorators import cmd, event_listener
+from src.messages import messages
+from src.events import Event
+
+REVEALED_MAYORS = set()
+
+@event_listener("rename_player")
+def on_rename_player(evt, cli, var, prefix, nick):
+    if prefix in REVEALED_MAYORS:
+        REVEALED_MAYORS.remove(prefix)
+        REVEALED_MAYORS.add(nick)
+
+@event_listener("chk_decision_lynch", priority=3)
+def on_chk_decision_lynch(evt, cli, var, voters):
+    votee = evt.data["votee"]
+    if votee in var.ROLES["mayor"] and votee not in REVEALED_MAYORS:
+        cli.msg(botconfig.CHANNEL, messages["mayor_reveal"].format(votee))
+        REVEALED_MAYORS.add(votee)
+        evt.data["votee"] = None
+        evt.prevent_default = True
+        evt.stop_processing = True
+
+@event_listener("reset")
+def on_reset(evt, var):
+    REVEALED_MAYORS.clear()
+
+# vim: set sw=4 expandtab:

--- a/src/roles/shaman.py
+++ b/src/roles/shaman.py
@@ -243,7 +243,8 @@ def on_chk_decision_lynch1(evt, cli, var, voters):
         if p in IMPATIENCE and p not in var.VOTES[votee]:
             cli.msg(botconfig.CHANNEL, messages["impatient_vote"].format(p, votee))
 
-@event_listener("chk_decision_lynch", priority=3)
+# mayor is at exactly 3, so we want that to always happen before revealing totem
+@event_listener("chk_decision_lynch", priority=3.1)
 def on_chk_decision_lynch3(evt, cli, var, voters):
     votee = evt.data["votee"]
     if votee in REVEALING:

--- a/src/wolfgame.py
+++ b/src/wolfgame.py
@@ -2065,13 +2065,6 @@ def chk_decision(cli, force=""):
                     }, del_player=del_player)
                 if vote_evt.dispatch(cli, var, voters):
                     votee = vote_evt.data["votee"]
-                    # roles that prevent any lynch from happening
-                    if votee in var.ROLES["mayor"] and votee not in var.REVEALED_MAYORS:
-                        cli.msg(botconfig.CHANNEL, messages["mayor_reveal"].format(votee))
-                        var.REVEALED_MAYORS.add(votee)
-                        event.data["transition_night"](cli)
-                        return
-
                     # roles that end the game upon being lynched
                     if votee in var.ROLES["fool"]:
                         # ends game immediately, with fool as only winner
@@ -3398,7 +3391,7 @@ def rename_player(cli, prefix, nick):
                 if b == prefix:
                     b = nick
                 var.EXCHANGED_ROLES[idx] = (a, b)
-            for setvar in (var.HEXED, var.SILENCED, var.REVEALED_MAYORS, var.MATCHMAKERS, var.PASSED,
+            for setvar in (var.HEXED, var.SILENCED, var.MATCHMAKERS, var.PASSED,
                            var.JESTERS, var.AMNESIACS, var.LYCANTHROPES, var.LUCKY, var.DISEASED,
                            var.MISDIRECTED, var.EXCHANGED, var.IMMUNIZED, var.CURED_LYCANS,
                            var.ALPHA_WOLVES, var.CURSED, var.CHARMERS, var.CHARMED, var.TOBECHARMED,
@@ -6097,7 +6090,6 @@ def start(cli, nick, chan, forced = False, restart = ""):
     var.TARGETED = {}
     var.LASTHEXED = {}
     var.MATCHMAKERS = set()
-    var.REVEALED_MAYORS = set()
     var.SILENCED = set()
     var.TOBESILENCED = set()
     var.JESTERS = set()


### PR DESCRIPTION
Also adjust revealing totem so that it always fires after mayor, in case
someone has both. Before it would depend on the order the files were
imported, which could lead to oddities down the road.

This fixes #256