### PR TITLE
Disallow pingif greater than or equal to var.MAX_PLAYERS

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -128,7 +128,7 @@
     "get_pingif": "You will be pinged when there are at least {0} players joined.",
     "no_pingif": "You do not have any ping preferences currently set.",
     "unset_pingif": "Your ping preferences have been removed (was {0}).",
-    "pingif_too_large": "That number is too large.",
+    "pingif_too_large": "Your ping preferences must be less than {0}. Use 0 to disable.",
     "pingif_already_set": "Your ping preferences are already set to {0}.",
     "pingif_change": "Your ping preferences have been changed from {0} to {1}.",
     "set_pingif": "Your ping preferences have been set to {0}.",

--- a/src/wolfgame.py
+++ b/src/wolfgame.py
@@ -699,8 +699,8 @@ def altpinger(cli, nick, chan, rest):
             num = int(rest[0])
         else:
             num = int(rest[1])
-        if num > 999:
-            msg.append(messages["pingif_too_large"])
+        if num >= var.MAX_PLAYERS:
+            msg.append(messages["pingif_too_large"].format(var.MAX_PLAYERS))
         elif players == num:
             msg.append(messages["pingif_already_set"].format(num))
         elif players:


### PR DESCRIPTION
There is no good reason to set your ping preferences to equal or exceed `var.MAX_PLAYERS`, as you won't be able to join at that point anyway, not even admins can `!fjoin` you.