### PR TITLE
Split traitor

### DIFF
--- a/src/roles/traitor.py
+++ b/src/roles/traitor.py
@@ -1,0 +1,40 @@
+import re
+import random
+import itertools
+import math
+from collections import defaultdict
+
+import botconfig
+import src.settings as var
+from src.utilities import *
+from src import debuglog, errlog, plog
+from src.decorators import cmd, event_listener
+from src.messages import messages
+from src.events import Event
+
+@event_listener("get_reveal_role")
+def on_get_reveal_role(evt, var, nick):
+    # in team reveal, show traitor as wolfteam, otherwise team stats won't sync with how
+    # they're revealed upon death. Team stats should show traitor as wolfteam or else
+    # the stats are wrong in that they'll report one less wolf than actually exists,
+    # which can confuse a lot of people
+    if evt.data["role"] == "traitor" and var.HIDDEN_TRAITOR and var.ROLE_REVEAL != "team":
+        evt.data["role"] = var.DEFAULT_ROLE
+
+@event_listener("get_final_role")
+def on_get_final_role(evt, cli, var, nick, role):
+    # if a traitor turns we want to show them as traitor in the end game readout
+    # instead of "wolf (was traitor)"
+    if role == "traitor" and evt.data["role"] == "wolf":
+        evt.data["role"] = "traitor"
+
+@event_listener("update_stats")
+def on_update_stats(evt, cli, var, nick, nickrole, nickreveal, nicktpls):
+    if nickrole == var.DEFAULT_ROLE and var.HIDDEN_TRAITOR:
+        evt.data["possible"].add("traitor")
+    # if this is a night death and we know for sure that wolves (and only wolves)
+    # killed, then that kill cannot be traitor as long as they're in wolfchat.
+    # TODO: need to figure out how to actually piece this together, but will
+    # likely require splitting off every other role first.
+
+# vim: set sw=4 expandtab:

--- a/src/utilities.py
+++ b/src/utilities.py
@@ -359,9 +359,7 @@ def get_roles(*roles):
     return list(itertools.chain(*all_roles))
 
 def get_reveal_role(nick):
-    if var.HIDDEN_TRAITOR and get_role(nick) == "traitor":
-        role = var.DEFAULT_ROLE
-    elif var.HIDDEN_AMNESIAC and nick in var.ORIGINAL_ROLES["amnesiac"]:
+    if var.HIDDEN_AMNESIAC and nick in var.ORIGINAL_ROLES["amnesiac"]:
         role = "amnesiac"
     elif var.HIDDEN_CLONE and nick in var.ORIGINAL_ROLES["clone"]:
         role = "clone"


### PR DESCRIPTION
As part of this, adjust team and accurate stats to no longer hide any
information. For team stats in particular, it was very misleading to
list traitor as villager, because it gives the village the impression
they have more time than they actually do (i.e. 2 wolfteam 5 vilteam
actually means 3 wolfteam 4 vilteam but that is not obvious). As team
stats were changed, team reveal was also changed to disregard hidden
traitor, so that the two can't be correlated to pick out if traitor died
(if traitor was revealed as vilteam but stats decremented wolfteam, that
would guarantee that traitor died).

Also commit groundwork for the stats rewrite, hidden behind an
"experimental" stats type (so it is not on by default). It is still very
WIP, many things do not yet work with it.