### PR TITLE
Removed comma in "... played Russian roulette, and lost"

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -80,7 +80,7 @@
         "\u0002{0}\u0002, a{1} \u0002{2}\u0002, fell off the roof of their house and is now dead.",
         "\u0002{0}\u0002 is crushed to death by a falling tree. The villagers desperately try to save the \u0002{2}\u0002, but it is too late.",
         "\u0002{0}\u0002 suddenly bursts into flames and is now all but a memory. The survivors bury the \u0002{2}\u0002's ashes.",
-        "\u0002{0}\u0002 played Russian roulette, and lost. The villagers bury the \u0002{2}\u0002's remains.",
+        "\u0002{0}\u0002 played Russian roulette and lost. The villagers bury the \u0002{2}\u0002's remains.",
         "\u0002{0}\u0002, a{1} \u0002{2}\u0002, poked a bear in the eye with a stick and has paid the price.",
         "\u0002{0}\u0002 tried to smoke dynamite. The resulting explosion has left a crater in place of the \u0002{2}\u0002.",
         "\u0002{0}\u0002, a{1} \u0002{2}\u0002, went spelunking and never made it back."


### PR DESCRIPTION
20:01:04 <+nyuszika7h> "beaky played Russian roulette, and lost"
20:01:10 <+nyuszika7h> I don't think there should be a comma there
20:01:58 <+nyuszika7h> idk though
20:02:04 <+nyuszika7h> it seems weird, though that's not a list of things