### PR TITLE
Kill weakrefs

### DIFF
--- a/src/channels.py
+++ b/src/channels.py
@@ -4,6 +4,7 @@ from enum import Enum
 
 from src.context import IRCContext, Features, lower
 from src.events import Event
+from src import settings as var
 from src import users
 
 Main = None # main channel
@@ -259,6 +260,9 @@ class Channel(IRCContext):
                 if not self.modes[mode]:
                     del self.modes[mode]
         del user.channels[self]
+        if len(user.channels) == 0:
+            event = Event("cleanup_user", {})
+            event.dispatch(var, user)
 
     def _clear(self):
         for user in self.users:


### PR DESCRIPTION
Weak references would normally be great, except Python does not specify behavior for garbage collection (indeed, having a gc at all is optional), and not all gc's do reference counting. This means the weak reference to a user may not be cleared in a reasonable amount of time (or ever), which causes subtle bugs.