### PR TITLE
In team reveal, be more clear about team names

### DIFF
--- a/src/utilities.py
+++ b/src/utilities.py
@@ -381,11 +381,11 @@ def get_reveal_role(nick):
         return role
 
     if role in var.WOLFTEAM_ROLES:
-        return "wolf"
+        return "wolfteam player"
     elif role in var.TRUE_NEUTRAL_ROLES:
         return "neutral player"
     else:
-        return "villager"
+        return "village member"
 
 def get_templates(nick):
     tpl = []


### PR DESCRIPTION
When a game is being played with team reveal instead of role reveal, use explicit team names instead of just "wolf" or "villager" to make it clear that we're referencing teams, not the similarly-named roles.