### PR TITLE
Support for TLS certificate verification and client certificates.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@
 __pycache__/
 *.py[co]
 
+# linter files
+.mypy_cache/
+
 # Config files
 botconfig.py
 /gamemodes.py

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@
 __pycache__/
 *.py[co]
 
-# linter files
+# Linter files
 .mypy_cache/
 
 # Config files

--- a/oyoyo/client.py
+++ b/oyoyo/client.py
@@ -203,7 +203,7 @@ class IRCClient:
                     # TLS session tickets harm forward secrecy (this symbol is only defined in 3.6 and later)
                     ctx.options |= ssl.OP_NO_TICKET
 
-                if self.cert_verify or self.cert_fp:
+                if self.cert_verify and not self.cert_fp:
                     ctx.verify_mode = ssl.CERT_REQUIRED
 
                     if not self.cert_fp:
@@ -211,8 +211,8 @@ class IRCClient:
 
                     ctx.load_default_certs()
 
-                else:
-                    self.stream_handler("NOT validating the server's TLS certificate! Set 'SSL_VERIFY=True' in botconfig.py to enable this.", level="warning")
+                elif not self.cert_verify and not self.cert_fp:
+                    self.stream_handler("NOT validating the server's TLS certificate! Set 'SSL_VERIFY=True' or define a fingerprint in 'SSL_CERTFP' in botconfig.py to enable this.", level="warning")
 
                 if self.client_certfile:
                     # if client_keyfile is not specified, the ssl module will look to the

--- a/oyoyo/client.py
+++ b/oyoyo/client.py
@@ -193,8 +193,8 @@ class IRCClient:
 
                 try:
                     self.socket = ctx.wrap_socket(self.socket)
-                except (ssl.CertificateError, ssl.SSLError, Exception) as error:
-                    print("Error occured while connecting with TLS: {0}".format(error))
+                except Exception as error:
+                    self.stream_handler("Error occured while connecting with TLS: {0}".format(error), level="warning")
                     raise
 
                 if self.cert_fp:
@@ -209,8 +209,8 @@ class IRCClient:
                     try:
                         h = hashlib.new(algo)
                     except ValueError as error:
-                        print("TLS certificate fingerprint verification failed: {}".format(error))
-                        print("Supported algorithms on this sytem: {0}".format(", ".join(hashlib.algorithms_available)))
+                        self.stream_handler("TLS certificate fingerprint verification failed: {}".format(error), level="warning")
+                        self.stream_handler("Supported algorithms on this sytem: {0}".format(", ".join(hashlib.algorithms_available)), level="warning")
                         raise
 
                     h.update(self.socket.getpeercert(True))
@@ -222,7 +222,7 @@ class IRCClient:
                             matched = fingerprint
 
                     if not matched:
-                        print("Certificate fingerprint {0} did not match any excpected fingerprints".format(peercertfp))
+                        self.stream_handler("Certificate fingerprint {0} did not match any excpected fingerprints".format(peercertfp), level="warning")
                         raise ssl.CertificateError("Certificate fingerprint does not match.")
 
                 if self.cert_verify and not self.cert_fp:
@@ -230,8 +230,8 @@ class IRCClient:
 
                     try:
                         ssl.match_hostname(cert, self.host)
-                    except ssl.CertificateError as error:
-                        print("TLS certificate verification failed: {0}".format(error))
+                    except Exception as error:
+                        self.stream_handler("TLS certificate verification failed: {0}".format(error), level="warning")
                         raise
 
 

--- a/oyoyo/client.py
+++ b/oyoyo/client.py
@@ -265,9 +265,7 @@ class IRCClient:
                         if not h:
                             fplen = len(fingerprint)
                             if fplen not in hashlen:
-                                self.stream_handler("Unable to auto-detect fingerprint #{0} ({1}) "
-                                                    "algorithm type by length".format(n, fp),
-                                                    level="warning")
+                                self.stream_handler("Unable to auto-detect fingerprint #{0} ({1}) algorithm type by length".format(n, fp), level="warning")
                                 continue
 
                             algo = hashlen[fplen]

--- a/src/settings.py
+++ b/src/settings.py
@@ -8,17 +8,17 @@ import botconfig
 LANGUAGE = 'en'
 
 ## TLS settings
-# if SSL_CERTFP is supplied, the bot will attempt to verify that with the server. if not, then the
+# If SSL_CERTFP is supplied, the bot will attempt to verify that with the server. If not, then the
 # bot will attempt certificate verification, otherwise it will abort the connection.
-# you may specify the hash algorithm to use when verifying fingerprints. if unspecified, it will
-# default to SHA256. multiple fingerprints may be comma separated for networks with multiple
-# servers. check your Python version for suported algorithms.
-# syntax: SSL_CERTFP = "[HASH-ALGO]:fingerprint1,fingerprint2,fingerprint3"
+# You may specify the hash algorithm to use when verifying fingerprints. If unspecified, it will
+# default to SHA256. Multiple fingerprints may be comma separated for networks with multiple
+# servers. Check your Python version for suported algorithms.
+# Xyntax: SSL_CERTFP = "[HASH-ALGO]:fingerprint1,fingerprint2,fingerprint3"
 SSL_VERIFY = True
-SSL_CERTFILE = None # client cert file to connect with in PEM format; can also contain keyfile
-SSL_KEYFILE = None # keyfile for the certfile in PEM format. if encrypted, password will prompt on the command line
+SSL_CERTFILE = None # Client cert file to connect with in PEM format; can also contain keyfile.
+SSL_KEYFILE = None # Keyfile for the certfile in PEM format. if encrypted, password will prompt on the command line.
 SSL_CERTFP = None
-SSL_CIPHERS = None # custom list of available ciphers in OpenSSL cipher list format (<https://wiki.openssl.org/index.php/Manual:Ciphers(1)#CIPHER_LIST_FORMAT>)
+SSL_CIPHERS = None # Custom list of available ciphers in OpenSSL cipher list format. (<https://wiki.openssl.org/index.php/Manual:Ciphers(1)#CIPHER_LIST_FORMAT>)
 
 MINIMUM_WAIT = 60
 EXTRA_WAIT = 30

--- a/src/settings.py
+++ b/src/settings.py
@@ -36,6 +36,7 @@ TIME_RATE_LIMIT = 10
 START_RATE_LIMIT = 10 # (per-user)
 WAIT_RATE_LIMIT = 10  # (per-user)
 GOAT_RATE_LIMIT = 300 # (per-user)
+GOAT_ATTACK_OWNER = {}  # users in this list will always be actioned by their own goats
 SHOTS_MULTIPLIER = .12  # ceil(shots_multiplier * len_players) = bullets given
 SHARPSHOOTER_MULTIPLIER = 0.06
 MIN_PLAYERS = 4

--- a/src/settings.py
+++ b/src/settings.py
@@ -11,9 +11,11 @@ LANGUAGE = 'en'
 # If SSL_CERTFP is supplied, the bot will attempt to verify that with the server. If not, then the
 # bot will attempt certificate verification, otherwise it will abort the connection.
 # You may specify the hash algorithm to use when verifying fingerprints. If unspecified, it will
-# default to SHA256. Multiple fingerprints may be comma separated for networks with multiple
-# servers. Check your Python version for suported algorithms.
-# Xyntax: SSL_CERTFP = "[HASH-ALGO]:fingerprint1,fingerprint2,fingerprint3"
+# attempt to autodetect the hash type of each fingerprint individually. (Limited to MD5, SHA1,
+# SHA224, SHA384, and SHA512).
+# Multiple fingerprints may be comma separated for networks with multipleservers. Check your Python
+# version for suported algorithms.
+# Syntax: SSL_CERTFP = "[HASH-ALGO:]fingerprint1,fingerprint2,fingerprint3"
 SSL_VERIFY = True
 SSL_CERTFILE = None # Client cert file to connect with in PEM format; can also contain keyfile.
 SSL_KEYFILE = None # Keyfile for the certfile in PEM format. if encrypted, password will prompt on the command line.

--- a/src/settings.py
+++ b/src/settings.py
@@ -18,6 +18,7 @@ SSL_VERIFY = True
 SSL_CERTFILE = None # client cert file to connect with in PEM format; can also contain keyfile
 SSL_KEYFILE = None # keyfile for the certfile in PEM format. if encrypted, password will prompt on the command line
 SSL_CERTFP = None
+SSL_CIPHERS = None # custom list of available ciphers in OpenSSL cipher list format (<https://wiki.openssl.org/index.php/Manual:Ciphers(1)#CIPHER_LIST_FORMAT>)
 
 MINIMUM_WAIT = 60
 EXTRA_WAIT = 30

--- a/src/settings.py
+++ b/src/settings.py
@@ -36,7 +36,6 @@ TIME_RATE_LIMIT = 10
 START_RATE_LIMIT = 10 # (per-user)
 WAIT_RATE_LIMIT = 10  # (per-user)
 GOAT_RATE_LIMIT = 300 # (per-user)
-GOAT_ATTACK_OWNER = {}  # users in this list will always be actioned by their own goats
 SHOTS_MULTIPLIER = .12  # ceil(shots_multiplier * len_players) = bullets given
 SHARPSHOOTER_MULTIPLIER = 0.06
 MIN_PLAYERS = 4

--- a/src/settings.py
+++ b/src/settings.py
@@ -6,6 +6,19 @@ from collections import defaultdict, OrderedDict
 import botconfig
 
 LANGUAGE = 'en'
+
+## TLS settings
+# if SSL_CERTFP is supplied, the bot will attempt to verify that with the server. if not, then the
+# bot will attempt certificate verification, otherwise it will abort the connection.
+# you may specify the hash algorithm to use when verifying fingerprints. if unspecified, it will
+# default to SHA256. multiple fingerprints may be comma separated for networks with multiple
+# servers. check your Python version for suported algorithms.
+# syntax: SSL_CERTFP = "[HASH-ALGO]:fingerprint1,fingerprint2,fingerprint3"
+SSL_VERIFY = True
+SSL_CERTFILE = None # client cert file to connect with in PEM format; can also contain keyfile
+SSL_KEYFILE = None # keyfile for the certfile in PEM format. if encrypted, password will prompt on the command line
+SSL_CERTFP = None
+
 MINIMUM_WAIT = 60
 EXTRA_WAIT = 30
 EXTRA_WAIT_JOIN = 0 # Add this many seconds to the waiting time for each !join

--- a/src/wolfgame.py
+++ b/src/wolfgame.py
@@ -2910,12 +2910,7 @@ def goat(var, wrapper, message):
     if not target:
         wrapper.pm(messages["not_enough_parameters"])
         return
-
-    if wrapper.source in var.GOAT_ATTACK_OWNER:
-        victim = wrapper.source
-    else:
-        victim, _ = users.complete_match(users.lower(target), wrapper.target.users)
-
+    victim, _ = users.complete_match(users.lower(target), wrapper.target.users)
     if not victim:
         wrapper.pm(messages["goat_target_not_in_channel"].format(target))
         return
@@ -2929,12 +2924,7 @@ def fgoat(var, wrapper, message):
     """Forces a goat to interact with anyone or anything, without limitations."""
 
     nick = message.split(' ')[0].strip()
-
-    if wrapper.source in var.GOAT_ATTACK_OWNER:
-        victim = wrapper.source
-    else:
-        victim, _ = users.complete_match(users.lower(nick), wrapper.target.users)
-
+    victim, _ = users.complete_match(users.lower(nick), wrapper.target.users)
     if victim:
         togoat = victim
     else:
@@ -3149,7 +3139,7 @@ def nick_change(evt, var, user, old_rawnick):
     if nick not in var.DISCONNECTED: # FIXME: Need to update this once var.DISCONNECTED holds User instances
         rename_player(var, user, nick) # FIXME: Fix when rename_player supports the new interface
 
-@event_listener("cleanup_user")
+@event_listener("cleanup_user") 
 def cleanup_user(evt, var, user):
     var.LAST_GOAT.pop(user, None)
 
@@ -3447,7 +3437,7 @@ def transition_day(cli, gameid=0):
 
     var.CHARMED.update(var.TOBECHARMED)
     var.TOBECHARMED.clear()
-
+    
     for crow, target in iter(var.OBSERVED.items()):
         if crow not in var.ROLES["werecrow"]:
             continue
@@ -6615,7 +6605,7 @@ def game_stats(cli, nick, chan, rest):
         if gamemode != "all" and gamemode not in var.GAME_MODES.keys():
             matches = complete_match(gamemode, var.GAME_MODES.keys())
             if len(matches) == 1:
-                gamemode = matches[0]
+                gamemode = matches[0]  
             if not matches:
                 cli.notice(nick, messages["invalid_mode"].format(rest[0]))
                 return
@@ -6700,7 +6690,7 @@ def player_stats(cli, nick, chan, rest):
                 reply(cli, nick, chan, messages["no_such_role"].format(role))
                 return
             if len(matches) > 1:
-                reply(cli, nick, chan, messages["ambiguous_role"].format(", ".join(matches)))
+                reply(cli, nick, chan, messages["ambiguous_role"].format(", ".join(matches))) 
                 return
             role = matches[0]
         # Attempt to find the player's stats
@@ -6731,7 +6721,7 @@ def vote_gamemode(var, wrapper, gamemode, doreply):
             return
         if len(matches) == 1:
             gamemode = matches[0]
-
+        
     if gamemode != "roles" and gamemode != "villagergame" and gamemode not in var.DISABLED_GAMEMODES:
         if var.GAMEMODE_VOTES.get(wrapper.source.nick) == gamemode:
             wrapper.pm(messages["already_voted_game"].format(gamemode))

--- a/src/wolfgame.py
+++ b/src/wolfgame.py
@@ -2910,7 +2910,12 @@ def goat(var, wrapper, message):
     if not target:
         wrapper.pm(messages["not_enough_parameters"])
         return
-    victim, _ = users.complete_match(users.lower(target), wrapper.target.users)
+
+    if wrapper.source in var.GOAT_ATTACK_OWNER:
+        victim = wrapper.source
+    else:
+        victim, _ = users.complete_match(users.lower(target), wrapper.target.users)
+
     if not victim:
         wrapper.pm(messages["goat_target_not_in_channel"].format(target))
         return
@@ -2924,7 +2929,12 @@ def fgoat(var, wrapper, message):
     """Forces a goat to interact with anyone or anything, without limitations."""
 
     nick = message.split(' ')[0].strip()
-    victim, _ = users.complete_match(users.lower(nick), wrapper.target.users)
+
+    if wrapper.source in var.GOAT_ATTACK_OWNER:
+        victim = wrapper.source
+    else:
+        victim, _ = users.complete_match(users.lower(nick), wrapper.target.users)
+
     if victim:
         togoat = victim
     else:
@@ -3139,7 +3149,7 @@ def nick_change(evt, var, user, old_rawnick):
     if nick not in var.DISCONNECTED: # FIXME: Need to update this once var.DISCONNECTED holds User instances
         rename_player(var, user, nick) # FIXME: Fix when rename_player supports the new interface
 
-@event_listener("cleanup_user") 
+@event_listener("cleanup_user")
 def cleanup_user(evt, var, user):
     var.LAST_GOAT.pop(user, None)
 
@@ -3437,7 +3447,7 @@ def transition_day(cli, gameid=0):
 
     var.CHARMED.update(var.TOBECHARMED)
     var.TOBECHARMED.clear()
-    
+
     for crow, target in iter(var.OBSERVED.items()):
         if crow not in var.ROLES["werecrow"]:
             continue
@@ -6605,7 +6615,7 @@ def game_stats(cli, nick, chan, rest):
         if gamemode != "all" and gamemode not in var.GAME_MODES.keys():
             matches = complete_match(gamemode, var.GAME_MODES.keys())
             if len(matches) == 1:
-                gamemode = matches[0]  
+                gamemode = matches[0]
             if not matches:
                 cli.notice(nick, messages["invalid_mode"].format(rest[0]))
                 return
@@ -6690,7 +6700,7 @@ def player_stats(cli, nick, chan, rest):
                 reply(cli, nick, chan, messages["no_such_role"].format(role))
                 return
             if len(matches) > 1:
-                reply(cli, nick, chan, messages["ambiguous_role"].format(", ".join(matches))) 
+                reply(cli, nick, chan, messages["ambiguous_role"].format(", ".join(matches)))
                 return
             role = matches[0]
         # Attempt to find the player's stats
@@ -6721,7 +6731,7 @@ def vote_gamemode(var, wrapper, gamemode, doreply):
             return
         if len(matches) == 1:
             gamemode = matches[0]
-        
+
     if gamemode != "roles" and gamemode != "villagergame" and gamemode not in var.DISABLED_GAMEMODES:
         if var.GAMEMODE_VOTES.get(wrapper.source.nick) == gamemode:
             wrapper.pm(messages["already_voted_game"].format(gamemode))

--- a/wolfbot.py
+++ b/wolfbot.py
@@ -51,6 +51,7 @@ from oyoyo.client import IRCClient
 import src
 from src import handler
 from src.events import Event
+import src.settings as var
 
 def main():
     evt = Event("init", {})
@@ -70,6 +71,10 @@ def main():
                      sasl_auth=botconfig.SASL_AUTHENTICATION,
                      server_pass=botconfig.SERVER_PASS,
                      use_ssl=botconfig.USE_SSL,
+                     cert_verify=var.SSL_VERIFY,
+                     cert_fp=var.SSL_CERTFP,
+                     client_certfile=var.SSL_CERTFILE,
+                     client_keyfile=var.SSL_KEYFILE,
                      connect_cb=handler.connect_callback,
                      stream_handler=src.stream,
     )

--- a/wolfbot.py
+++ b/wolfbot.py
@@ -75,6 +75,7 @@ def main():
                      cert_fp=var.SSL_CERTFP,
                      client_certfile=var.SSL_CERTFILE,
                      client_keyfile=var.SSL_KEYFILE,
+                     cipher_list=var.SSL_CIPHERS,
                      connect_cb=handler.connect_callback,
                      stream_handler=src.stream,
     )


### PR DESCRIPTION
If a TLS certificate fingerprint is provided, the client will check it against the SHA256 hex digest of the server's certificate. Different hash algorithms can be specified, and multiple fingerprints can be specified for networks with more than one server.

Not sure if `print()` is the right thing to do within the `connect()` method in order to display to the user when certificate validation fails.