### PR TITLE
Fix return_to_village for disconnected users

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -158,6 +158,7 @@
     "account_reidentify": "Please reidentify to the account \u0002{0}\u0002",
     "account_midgame_change": "Please do not change accounts midgame",
     "player_return": "\u0002{0}\u0002 has returned to the village.",
+    "player_return_nickchange": "\u0002{0}\u0002 has returned to the village (was \u0002{1}\u0002).",
     "command_ratelimited": "This command is rate-limited. Please wait a while before using it again.",
     "stats": "{0}It is currently {4}. There {3} {1}, and {2}.",
     "daylight_warning": "\u0002As the sun sinks inexorably toward the horizon, turning the lanky pine trees into fire-edged silhouettes, the villagers are reminded that very little time remains for them to reach a decision; if darkness falls before they have done so, the majority will win the vote. No one will be lynched if there are no votes or an even split.\u0002",


### PR DESCRIPTION
If the user rejoins as a different user, the ghost stuck around and
broke things. This fixes that. It also makes it smarter when rejoining
as a different nick, and alerts what the old nick was in such cases.