### PR TITLE
Convert var.ROLES and var.ORIGINAL_ROLES to Users

### DIFF
--- a/src/channels.py
+++ b/src/channels.py
@@ -303,3 +303,5 @@ class FakeChannel(Channel):
                     targets.append(target)
 
         self.update_modes(users.Bot.rawnick, "".join(modes), targets)
+
+# vim: set sw=4 expandtab:

--- a/src/context.py
+++ b/src/context.py
@@ -224,3 +224,5 @@ class IRCContext:
         if sep is None:
             sep = " "
         _send(data, first, sep, self.client, send_type, name)
+
+# vim: set sw=4 expandtab:

--- a/src/decorators.py
+++ b/src/decorators.py
@@ -287,7 +287,7 @@ class command:
             return
 
         for role in self.roles:
-            if user.nick in var.ROLES[role]: # FIXME: Need to change this once var.ROLES[role] holds User instances
+            if user in var.ROLES[role]:
                 break
         else:
             if (self.users is not None and user not in self.users) or self.roles:
@@ -434,7 +434,7 @@ class cmd:
             return
 
         for role in self.roles:
-            if nick in var.ROLES[role]:
+            if users._get(nick) in var.ROLES[role]:
                 break
         else:
             if (self.nicks is not None and nick not in self.nicks) or self.roles:

--- a/src/dispatcher.py
+++ b/src/dispatcher.py
@@ -46,3 +46,5 @@ class MessageDispatcher:
         else:
             kwargs.setdefault("first", first)
             self.target.send(*messages, **kwargs)
+
+# vim: set sw=4 expandtab:

--- a/src/functions.py
+++ b/src/functions.py
@@ -21,13 +21,15 @@ def get_players(roles=None, *, mainroles=None):
         return list(pl)
     return [p for p in var.ALL_PLAYERS if p in pl]
 
-def get_all_players(roles=None):
+def get_all_players(roles=None, *, rolemap=None):
+    if rolemap is None:
+        rolemap = var.ROLES
     if roles is None:
-        roles = var.ROLES
+        roles = set(rolemap.keys())
     pl = set()
     for role in roles:
-        for nick in var.ROLES[role]:
-            pl.add(users._get(nick)) # FIXME
+        for user in rolemap[role]:
+            pl.add(user)
 
     return pl
 
@@ -73,4 +75,6 @@ def get_main_role(user):
     return role
 
 def get_all_roles(user):
-    return {role for role, nicks in var.ROLES.items() if user.nick in nicks}
+    return {role for role, users in var.ROLES.items() if user in users}
+
+# vim: set sw=4 expandtab:

--- a/src/gamemodes.py
+++ b/src/gamemodes.py
@@ -215,7 +215,7 @@ class VillagergameMode(GameMode):
         evt.data["transition_day"] = lambda cli, gameid=0: self.prolong_night(cli, var, gameid, transition_day)
 
     def prolong_night(self, cli, var, gameid, transition_day):
-        nspecials = len(var.ROLES["seer"] | var.ROLES["harlot"] | var.ROLES["shaman"] | var.ROLES["crazed shaman"])
+        nspecials = len(get_players(("seer", "harlot", "shaman", "crazed shaman")))
         rand = random.gauss(5, 1.5)
         if rand <= 0 and nspecials > 0:
             transition_day(cli, gameid=gameid)
@@ -227,7 +227,7 @@ class VillagergameMode(GameMode):
         # 30% chance we kill a safe, otherwise kill at random
         # when killing safes, go after seer, then harlot, then shaman
         self.delaying_night = False
-        pl = list_players()
+        pl = get_players()
         tgt = None
         seer = None
         hlt = None
@@ -238,10 +238,9 @@ class VillagergameMode(GameMode):
         if len(var.ROLES["harlot"]) == 1:
             hlt = list(var.ROLES["harlot"])[0]
             from src.roles import harlot
-            hvst = harlot.VISITED.get(users._get(hlt)) # FIXME
+            hvst = harlot.VISITED.get(hlt)
             if hvst is not None:
                 pl.remove(hlt)
-                hvst = hvst.nick # FIXME
         if len(var.ROLES["shaman"]) == 1:
             shmn = list(var.ROLES["shaman"])[0]
         if random.random() < 0.3:
@@ -256,7 +255,7 @@ class VillagergameMode(GameMode):
         if not tgt:
             tgt = random.choice(pl)
         from src.roles import wolf
-        wolf.KILLS[botconfig.NICK] = [tgt]
+        wolf.KILLS[botconfig.NICK] = [tgt.nick]
 
     def on_retribution_kill(self, evt, var, victim, orig_target):
         # There are no wolves for this totem to kill
@@ -914,7 +913,7 @@ class SleepyMode(GameMode):
 
     def dullahan_targets(self, evt, cli, var, dullahans, max_targets):
         for dull in dullahans:
-            evt.data["targets"][dull] = {users._get(x) for x in var.ROLES["priest"]}
+            evt.data["targets"][dull] = set(var.ROLES["priest"])
 
     def setup_nightmares(self, evt, cli, var):
         if random.random() < 1/5:
@@ -1225,7 +1224,7 @@ class MaelstromMode(GameMode):
         from src import hooks, channels
         role = random.choice(self.roles)
         rolemap = copy.deepcopy(var.ROLES)
-        rolemap[role].add(wrapper.source.nick) # FIXME: add user instead of nick (can only be done once var.ROLES itself uses users)
+        rolemap[role].add(wrapper.source)
         mainroles = copy.deepcopy(var.MAIN_ROLES)
         mainroles[wrapper.source] = role
 
@@ -1238,9 +1237,9 @@ class MaelstromMode(GameMode):
                 cmodes.append(("-" + mode, wrapper.source))
                 var.OLD_MODES[wrapper.source].add(mode)
             channels.Main.mode(*cmodes)
-        var.ROLES[role].add(wrapper.source.nick) # FIXME: add user instead of nick
-        var.ORIGINAL_ROLES[role].add(wrapper.source.nick)
-        var.FINAL_ROLES[wrapper.source.nick] = role
+        var.ROLES[role].add(wrapper.source)
+        var.ORIGINAL_ROLES[role].add(wrapper.source)
+        var.FINAL_ROLES[wrapper.source.nick] = role # FIXME: once FINAL_ROLES stores users
         var.MAIN_ROLES[wrapper.source] = role
         var.LAST_SAID_TIME[wrapper.source.nick] = datetime.now()
         if wrapper.source.nick in var.USERS:
@@ -1258,19 +1257,19 @@ class MaelstromMode(GameMode):
             relay_wolfchat_command(wrapper.source.client, wrapper.source.nick, messages["wolfchat_new_member"].format(wrapper.source.nick, role), var.WOLFCHAT_ROLES, is_wolf_command=True, is_kill_command=True)
             # TODO: make this part of !myrole instead, no reason we can't give out wofllist in that
             wolves = list_players(var.WOLFCHAT_ROLES)
-            pl = list_players()
+            pl = get_players()
             random.shuffle(pl)
-            pl.remove(wrapper.source.nick)
+            pl.remove(wrapper.source)
             for i, player in enumerate(pl):
-                prole = get_role(player)
+                prole = get_main_role(player)
                 if prole in var.WOLFCHAT_ROLES:
                     cursed = ""
                     if player in var.ROLES["cursed villager"]:
                         cursed = "cursed "
                     pl[i] = "\u0002{0}\u0002 ({1}{2})".format(player, cursed, prole)
                 elif player in var.ROLES["cursed villager"]:
-                    pl[i] = player + " (cursed)"
-            wrapper.pm("Players: " + ", ".join(pl))
+                    pl[i] = player.nick + " (cursed)"
+            wrapper.pm("Players: " + ", ".join(p.nick for p in pl))
 
     def role_attribution(self, evt, cli, var, chk_win_conditions, villagers):
         self.chk_win_conditions = chk_win_conditions
@@ -1280,7 +1279,7 @@ class MaelstromMode(GameMode):
         # don't do this n1
         if var.FIRST_NIGHT:
             return
-        villagers = list_players()
+        villagers = get_players()
         lpl = len(villagers)
         addroles = self._role_attribution(cli, var, villagers, False)
 
@@ -1293,7 +1292,7 @@ class MaelstromMode(GameMode):
 
         # Handle roles that need extra help
         for doctor in var.ROLES["doctor"]:
-            var.DOCTORS[doctor] = math.ceil(var.DOCTOR_IMMUNIZATION_MULTIPLIER * lpl)
+            var.DOCTORS[doctor.nick] = math.ceil(var.DOCTOR_IMMUNIZATION_MULTIPLIER * lpl)
 
         # Clear totem tracking; this would let someone that gets shaman twice in a row to give
         # out a totem to the same person twice in a row, but oh well
@@ -1312,8 +1311,8 @@ class MaelstromMode(GameMode):
                         continue
                     var.ORIGINAL_ROLES[r].discard(p)
                 var.ORIGINAL_ROLES[role].add(p)
-                var.FINAL_ROLES[p] = role
-                var.MAIN_ROLES[users._get(p)] = role # FIXME
+                var.FINAL_ROLES[p.nick] = role # FIXME
+                var.MAIN_ROLES[p] = role
 
     def _role_attribution(self, cli, var, villagers, do_templates):
         lpl = len(villagers) - 1
@@ -1349,7 +1348,7 @@ class MaelstromMode(GameMode):
             if count > 0:
                 for j in range(count):
                     u = users.FakeUser.from_nick(str(i + j))
-                    rolemap[role].add(u.nick)
+                    rolemap[role].add(u)
                     if role not in var.TEMPLATE_RESTRICTIONS:
                         mainroles[u] = role
                 i += count

--- a/src/gamemodes.py
+++ b/src/gamemodes.py
@@ -215,7 +215,7 @@ class VillagergameMode(GameMode):
         evt.data["transition_day"] = lambda cli, gameid=0: self.prolong_night(cli, var, gameid, transition_day)
 
     def prolong_night(self, cli, var, gameid, transition_day):
-        nspecials = len(get_players(("seer", "harlot", "shaman", "crazed shaman")))
+        nspecials = len(get_all_players(("seer", "harlot", "shaman", "crazed shaman")))
         rand = random.gauss(5, 1.5)
         if rand <= 0 and nspecials > 0:
             transition_day(cli, gameid=gameid)

--- a/src/roles/angel.py
+++ b/src/roles/angel.py
@@ -146,10 +146,10 @@ def on_transition_day(evt, var):
                         var.ACTIVE_PROTECTIONS[v.nick].append("bodyguard")
         else:
             for g in var.ROLES["guardian angel"]:
-                if GUARDED.get(g) == v.nick:
+                if GUARDED.get(g.nick) == v.nick:
                     var.ACTIVE_PROTECTIONS[v.nick].append("angel")
             for g in var.ROLES["bodyguard"]:
-                if GUARDED.get(g) == v.nick:
+                if GUARDED.get(g.nick) == v.nick:
                     var.ACTIVE_PROTECTIONS[v.nick].append("bodyguard")
 
 @event_listener("fallen_angel_guard_break")
@@ -277,10 +277,10 @@ def on_assassinate(evt, var, killer, target, prot):
         evt.prevent_default = True
         evt.stop_processing = True
         for bg in var.ROLES["bodyguard"]:
-            if GUARDED.get(bg) == target.nick:
+            if GUARDED.get(bg.nick) == target.nick:
                 channels.Main.send(messages[evt.params.message_prefix + "bodyguard"].format(killer, target, bg))
                 # redirect the assassination to the bodyguard
-                evt.data["target"] = users._get(bg) # FIXME
+                evt.data["target"] = bg
                 break
 
 @event_listener("begin_day")

--- a/src/roles/blessed.py
+++ b/src/roles/blessed.py
@@ -75,7 +75,7 @@ def on_assassinate(evt, var, killer, target, prot):
 
 @event_listener("myrole")
 def on_myrole(evt, var, user):
-    if user.nick in var.ROLES["blessed villager"]:
+    if user in var.ROLES["blessed villager"]:
         evt.data["messages"].append(messages["blessed_simple"])
 
 # vim: set sw=4 expandtab:

--- a/src/roles/cursed.py
+++ b/src/roles/cursed.py
@@ -14,12 +14,12 @@ from src.events import Event
 
 @event_listener("see")
 def on_see(evt, cli, var, nick, victim):
-    if victim in var.ROLES["cursed villager"]:
+    if users._get(victim) in var.ROLES["cursed villager"]: # FIXME
         evt.data["role"] = "wolf"
 
 @event_listener("wolflist")
 def on_wolflist(evt, var, player, wolf):
-    if player.nick in var.ROLES["cursed villager"]:
+    if player in var.ROLES["cursed villager"]:
         evt.data["tags"].add("cursed")
 
 # vim: set sw=4 expandtab:

--- a/src/roles/detective.py
+++ b/src/roles/detective.py
@@ -79,7 +79,7 @@ def on_exchange(evt, var, actor, target, actor_role, target_role):
 @event_listener("transition_night_end", priority=2)
 def on_transition_night_end(evt, var):
     ps = get_players()
-    for dttv in get_all_players(("detective",)):
+    for dttv in var.ROLES["detective"]:
         pl = ps[:]
         random.shuffle(pl)
         pl.remove(dttv)

--- a/src/roles/dullahan.py
+++ b/src/roles/dullahan.py
@@ -179,9 +179,9 @@ def on_role_assignment(evt, cli, var, gamemode, pl, restart):
     if var.ROLES["dullahan"]:
         max_targets = math.ceil(8.1 * math.log(len(pl), 10) - 5)
         for dull in var.ROLES["dullahan"]:
-            TARGETS[users._get(dull)] = set() # FIXME
+            TARGETS[dull] = set()
         dull_targets = Event("dullahan_targets", {"targets": TARGETS}) # support sleepy
-        dull_targets.dispatch(cli, var, {users._get(x) for x in var.ROLES["dullahan"]}, max_targets) # FIXME
+        dull_targets.dispatch(cli, var, var.ROLES["dullahan"], max_targets)
 
         players = [users._get(x) for x in pl] # FIXME
 
@@ -199,19 +199,19 @@ def on_succubus_visit(evt, cli, var, nick, victim):
     if user in TARGETS:
         succ_target = False
         for target in set(TARGETS[user]):
-            if target.nick in var.ROLES["succubus"]:
+            if target in var.ROLES["succubus"]:
                 TARGETS[user].remove(target)
                 succ_target = True
         if succ_target:
             pm(cli, victim, messages["dullahan_no_kill_succubus"])
-    if user in KILLS and KILLS[user].nick in var.ROLES["succubus"]:
+    if user in KILLS and KILLS[user] in var.ROLES["succubus"]:
         pm(cli, victim, messages["no_kill_succubus"].format(KILLS[user]))
         del KILLS[user]
 
 @event_listener("myrole")
 def on_myrole(evt, var, user):
     # Remind dullahans of their targets
-    if user.nick in var.ROLES["dullahan"]:
+    if user in var.ROLES["dullahan"]:
         targets = list(TARGETS[user])
         for target in list(targets):
             if target.nick in var.DEAD:
@@ -250,8 +250,7 @@ def on_get_role_metadata(evt, var, kind):
     if kind == "night_kills":
         num = 0
         for dull in var.ROLES["dullahan"]:
-            user = users._get(dull) # FIXME
-            for target in TARGETS[user]:
+            for target in TARGETS[dull]:
                 if target.nick not in var.DEAD:
                     num += 1
                     break

--- a/src/roles/harlot.py
+++ b/src/roles/harlot.py
@@ -59,7 +59,7 @@ def pass_cmd(var, wrapper, message):
 
 @event_listener("bite")
 def on_bite(evt, var, alpha, target):
-    if target.nick not in var.ROLES["harlot"] or target not in VISITED:
+    if target not in var.ROLES["harlot"] or target not in VISITED:
         return
     hvisit = VISITED[target]
     if get_main_role(hvisit) not in var.WOLFCHAT_ROLES and (hvisit not in evt.params.bywolves or hvisit in evt.params.protected):
@@ -67,7 +67,7 @@ def on_bite(evt, var, alpha, target):
 
 @event_listener("transition_day_resolve", priority=1)
 def on_transition_day_resolve(evt, var, victim):
-    if victim.nick in var.ROLES["harlot"] and VISITED.get(victim) and victim not in evt.data["dead"] and victim in evt.data["onlybywolves"]:
+    if victim in var.ROLES["harlot"] and VISITED.get(victim) and victim not in evt.data["dead"] and victim in evt.data["onlybywolves"]:
         if victim not in evt.data["bitten"]:
             evt.data["message"].append(messages["target_not_home"])
             evt.data["novictmsg"] = False

--- a/src/roles/hunter.py
+++ b/src/roles/hunter.py
@@ -140,7 +140,7 @@ def on_transition_night_end(evt, var):
 @event_listener("succubus_visit")
 def on_succubus_visit(evt, cli, var, nick, victim):
     user = users._get(victim) # FIXME
-    if user in KILLS and KILLS[user].nick in var.ROLES["succubus"]: # FIXME
+    if user in KILLS and KILLS[user] in var.ROLES["succubus"]:
         user.send(messages["no_kill_succubus"].format(KILLS[user]))
         del KILLS[user]
         HUNTERS.discard(user)
@@ -161,7 +161,7 @@ def on_get_role_metadata(evt, var, kind):
     if kind == "night_kills":
         # hunters is the set of all hunters that have not killed in a *previous* night
         # (if they're in both HUNTERS and KILLS, then they killed tonight and should be counted)
-        hunters = ({users._get(h) for h in var.ROLES["hunter"]} - HUNTERS) | set(KILLS.keys()) # FIXME
+        hunters = (var.ROLES["hunter"] - HUNTERS) | set(KILLS.keys())
         evt.data["hunter"] = len(hunters)
 
 # vim: set sw=4 expandtab:

--- a/src/roles/madscientist.py
+++ b/src/roles/madscientist.py
@@ -163,7 +163,7 @@ def on_transition_night_end(evt, var):
 
 @event_listener("myrole")
 def on_myrole(evt, var, user):
-    if user.nick in var.ROLES["mad scientist"]:
+    if user in var.ROLES["mad scientist"]:
         pl = get_players()
         target1, target2 = _get_targets(var, pl, user)
         evt.data["messages"].append(messages["mad_scientist_myrole_targets"].format(target1, target2))

--- a/src/roles/mayor.py
+++ b/src/roles/mayor.py
@@ -23,7 +23,7 @@ def on_rename_player(evt, cli, var, prefix, nick):
 @event_listener("chk_decision_lynch", priority=3)
 def on_chk_decision_lynch(evt, cli, var, voters):
     votee = evt.data["votee"]
-    if votee in var.ROLES["mayor"] and votee not in REVEALED_MAYORS:
+    if users._get(votee) in var.ROLES["mayor"] and votee not in REVEALED_MAYORS: # FIXME
         cli.msg(botconfig.CHANNEL, messages["mayor_reveal"].format(votee))
         REVEALED_MAYORS.add(votee)
         evt.data["votee"] = None

--- a/src/roles/shaman.py
+++ b/src/roles/shaman.py
@@ -455,7 +455,7 @@ def on_transition_day_resolve6(evt, var, victim):
     # that will not be an issue once everything is using the event
     if evt.data["protected"].get(victim):
         return
-    if victim.nick in var.ROLES["lycan"] and victim in evt.data["onlybywolves"] and victim.nick not in var.IMMUNIZED:
+    if victim in var.ROLES["lycan"] and victim in evt.data["onlybywolves"] and victim.nick not in var.IMMUNIZED:
         return
     # END checks to remove
 
@@ -540,7 +540,7 @@ def on_transition_night_end(evt, var):
                 shaman.send(messages["totem_simple"].format(TOTEMS[shaman.nick])) # FIXME
         else:
             if role not in var.WOLFCHAT_ROLES:
-                shaman.send(messages["shaman_notify"].format(role, "random " if shaman.nick in var.ROLES["crazed shaman"] else "")) # FIXME
+                shaman.send(messages["shaman_notify"].format(role, "random " if shaman in var.ROLES["crazed shaman"] else ""))
             if role != "crazed shaman":
                 totem = TOTEMS[shaman.nick] # FIXME
                 tmsg = messages["shaman_totem"].format(totem)
@@ -587,7 +587,7 @@ def on_assassinate(evt, var, killer, target, prot):
 
 @event_listener("succubus_visit")
 def on_succubus_visit(evt, cli, var, nick, victim):
-    if (SHAMANS.get(victim, (None, None))[1] in var.ROLES["succubus"] and
+    if (users._get(SHAMANS.get(victim, (None, None))[1]) in var.ROLES["succubus"] and # FIXME (psst Vgr: this probably breaks now if the shaman didn't give out totems when succ visits)
        (get_role(victim) == "crazed shaman" or TOTEMS[victim] not in var.BENEFICIAL_TOTEMS)):
         pm(cli, victim, messages["retract_totem_succubus"].format(SHAMANS[victim]))
         del SHAMANS[victim]

--- a/src/roles/shaman.py
+++ b/src/roles/shaman.py
@@ -587,7 +587,7 @@ def on_assassinate(evt, var, killer, target, prot):
 
 @event_listener("succubus_visit")
 def on_succubus_visit(evt, cli, var, nick, victim):
-    if (users._get(SHAMANS.get(victim, (None, None))[1]) in var.ROLES["succubus"] and # FIXME (psst Vgr: this probably breaks now if the shaman didn't give out totems when succ visits)
+    if (users._get(SHAMANS.get(victim, (None, None))[1], allow_none=True) in var.ROLES["succubus"] and
        (get_role(victim) == "crazed shaman" or TOTEMS[victim] not in var.BENEFICIAL_TOTEMS)):
         pm(cli, victim, messages["retract_totem_succubus"].format(SHAMANS[victim]))
         del SHAMANS[victim]

--- a/src/roles/traitor.py
+++ b/src/roles/traitor.py
@@ -67,16 +67,16 @@ def on_chk_win(evt, cli, var, rolemap, mainroles, lpl, lwolves, lrealwolves):
             rolemap["wolf"].add(traitor)
             rolemap["traitor"].remove(traitor)
             rolemap["cursed villager"].discard(traitor)
-            mainroles[users._get(traitor)] = "wolf" # FIXME
+            mainroles[traitor] = "wolf"
             did_something = True
             if var.PHASE in var.GAME_PHASES:
-                var.FINAL_ROLES[traitor] = "wolf"
-                pm(cli, traitor, messages["traitor_turn"])
+                var.FINAL_ROLES[traitor.nick] = "wolf" # FIXME
+                traitor.send(messages["traitor_turn"])
                 debuglog(traitor, "(traitor) TURNING")
     if did_something:
         if var.PHASE in var.GAME_PHASES:
             var.TRAITOR_TURNED = True
-            cli.msg(botconfig.CHANNEL, messages["traitor_turn_channel"])
+            channels.Main.send(messages["traitor_turn_channel"])
         evt.prevent_default = True
         evt.stop_processing = True
 

--- a/src/roles/vigilante.py
+++ b/src/roles/vigilante.py
@@ -125,7 +125,7 @@ def on_transition_night_end(evt, var):
 def on_succubus_visit(evt, cli, var, nick, victim):
     for vigilante, target in set(KILLS.items()):
         if vigilante.nick == victim:
-            if target.nick in var.ROLES["succubus"]:
+            if target in var.ROLES["succubus"]:
                 vigilante.send(messages["no_kill_succubus"].format(target))
                 del KILLS[vigilante]
 

--- a/src/roles/wildchild.py
+++ b/src/roles/wildchild.py
@@ -92,7 +92,7 @@ def on_del_player(evt, var, user, mainrole, allroles, death_triggers):
         child.send(messages["idol_died"])
         WILD_CHILDREN.add(child.nick)
         change_role(child, get_main_role(child), "wolf")
-        var.ROLES["wild child"].discard(child.nick)
+        var.ROLES["wild child"].discard(child)
 
         wcroles = var.WOLFCHAT_ROLES
         if var.RESTRICT_WOLFCHAT & var.RW_REM_NON_WOLVES:

--- a/src/roles/wolf.py
+++ b/src/roles/wolf.py
@@ -102,7 +102,7 @@ def wolf_retract(cli, nick, chan, rest):
         del KILLS[nick]
         pm(cli, nick, messages["retracted_kill"])
         relay_wolfchat_command(cli, nick, messages["wolfchat_retracted_kill"].format(nick), var.WOLF_ROLES, is_wolf_command=True, is_kill_command=True)
-    if nick in var.ROLES["alpha wolf"] and nick in var.BITE_PREFERENCES:
+    if users._get(nick) in var.ROLES["alpha wolf"] and nick in var.BITE_PREFERENCES: # FIXME
         del var.BITE_PREFERENCES[nick]
         var.ALPHA_WOLVES.remove(nick)
         pm(cli, nick, messages["no_bite"])
@@ -414,7 +414,7 @@ def on_transition_night_end(evt, var):
         elif role == "warlock":
             # warlock specifically only sees cursed if they're not in wolfchat
             for player in pl:
-                if player.nick in var.ROLES["cursed villager"]: # FIXME: Once var.ROLES holds User instances
+                if player in var.ROLES["cursed villager"]:
                     players.append(player.nick + " (cursed)")
                 else:
                     players.append(player.nick)
@@ -428,11 +428,11 @@ def on_transition_night_end(evt, var):
 
 @event_listener("succubus_visit")
 def on_succubus_visit(evt, cli, var, nick, victim):
-    if var.ROLES["succubus"].intersection(KILLS.get(victim, ())):
+    if var.ROLES["succubus"].intersection(users._get(x) for x in KILLS.get(victim, ())): # FIXME: once KILLS holds User instances
         for s in var.ROLES["succubus"]:
-            if s in KILLS[victim]:
+            if s.nick in KILLS[victim]: # FIXME
                 pm(cli, victim, messages["no_kill_succubus"].format(nick))
-                KILLS[victim].remove(s)
+                KILLS[victim].remove(s.nick) # FIXME
         if not KILLS[victim]:
             del KILLS[victim]
 

--- a/src/users.py
+++ b/src/users.py
@@ -642,3 +642,5 @@ class BotUser(User): # TODO: change all the 'if x is Bot' for 'if isinstance(x, 
         if nick is None:
             nick = self.nick
         self.client.send("NICK", nick)
+
+# vim: set sw=4 expandtab:

--- a/src/utilities.py
+++ b/src/utilities.py
@@ -211,7 +211,7 @@ def irc_lower(nick):
 def irc_equals(nick1, nick2):
     return irc_lower(nick1) == irc_lower(nick2)
 
-is_role = lambda plyr, rol: rol in var.ROLES and plyr in var.ROLES[rol]
+is_role = lambda plyr, rol: rol in var.ROLES and users._get(plyr) in var.ROLES[rol]
 
 def match_hostmask(hostmask, nick, ident, host):
     # support n!u@h, u@h, or just h by itself
@@ -344,7 +344,7 @@ def get_roles(*roles, rolemap=None):
     all_roles = []
     for role in roles:
         all_roles.append(rolemap[role])
-    return list(itertools.chain(*all_roles))
+    return [u.nick for u in itertools.chain(*all_roles)]
 
 def get_reveal_role(nick):
     # FIXME: make the arg a user instead of a nick
@@ -371,18 +371,18 @@ def get_reveal_role(nick):
         return "village member"
 
 def get_templates(nick):
-    # FIXME: make the arg a user instead of a nick
     mainrole = get_role(nick)
     tpl = []
-    for role, nicks in var.ROLES.items():
-        if nick in nicks and role != mainrole:
+    for role, users in var.ROLES.items():
+        if users._get(nick) in users and role != mainrole:
             tpl.append(role)
 
     return tpl
 
+# TODO: move this to functions.py
 def change_role(user, oldrole, newrole, set_final=True):
-    var.ROLES[oldrole].remove(user.nick)
-    var.ROLES[newrole].add(user.nick)
+    var.ROLES[oldrole].remove(user)
+    var.ROLES[newrole].add(user)
     # only adjust MAIN_ROLES/FINAL_ROLES if we're changing the user's actual role
     if var.MAIN_ROLES[user] == oldrole:
         var.MAIN_ROLES[user] = newrole


### PR DESCRIPTION
This gets rid of the (dced) hack, with var.DCED_LOSERS taking its place.
Succubus was not touched, as there is already a PR which converts it,
although the succubus events in other files were touched.

Some sites were updated to be (more) Users-aware, while others replaced
it with an old deprecated get_roles() API. As more things get converted,
these will hopefully get eliminated as well. A FIXME comment was added
to all such occurrences.