### PR TITLE
Add centralized error reporting (off by default)

### DIFF
--- a/src/decorators.py
+++ b/src/decorators.py
@@ -121,9 +121,25 @@ class print_traceback:
 
         variables[1] = _local.handler.traceback
 
-        if not botconfig.PASTEBIN_ERRORS or channels.Main is not channels.Dev:
+        if var.REPORT_ERRORS:
+            api_url = "https://werewolf.chat/devsite/report.php"
+            api_body = logger.get_replay(source)
+            api_body["traceback"] = variables
+
+            data = None
+            with _local.handler:
+                req = urllib.request.Request(api_url, json.dumps(api_body), {
+                    "Content-type": "application/json",
+                    "Accept": "application/json"
+                    }, method="POST")
+                resp = urllib.request.urlopen(req)
+                data = json.loads(resp.read().decode("utf-8"))
+            if data is None:
+                variables[1] = _local.handler.traceback # error reporting our error, update traceback
+
+        if not var.PASTEBIN_ERRORS or channels.Main is not channels.Dev:
             channels.Main.send(messages["error_log"])
-        if botconfig.PASTEBIN_ERRORS and channels.Dev is not None:
+        if var.PASTEBIN_ERRORS and channels.Dev is not None:
             message = [messages["error_log"]]
 
             link_uuid = _tracebacks.get("\n".join(variables))

--- a/src/logger.py
+++ b/src/logger.py
@@ -1,11 +1,28 @@
 import datetime
 import time
+import subprocess
+import platform
 
 import botconfig
+import src.settings as var
+from src import events
+
+# maintain a log of all messages for the current game, wiped on game reset
+# only populated if REPORT_ERRORS is True, otherwise is unnecessary overhead
+_memlog = {}
+
+def _clear_memlog(evt, var):
+    for channel in _memlog:
+        _memlog[channel].clear()
+events.add_listener("reset", _clear_memlog)
 
 def logger(file, write=True, display=True):
     if file is not None:
         open(file, "a").close() # create the file if it doesn't exist
+        channel = file.split(".")[0]
+    if file is None:
+        channel = "*"
+    _memlog[channel] = []
     def log(*output, write=write, display=display):
         output = " ".join([str(x) for x in output]).replace("\u0002", "").replace("\\x02", "") # remove bold
         if botconfig.DEBUG_MODE:
@@ -13,6 +30,8 @@ def logger(file, write=True, display=True):
         if botconfig.DEBUG_MODE or botconfig.VERBOSE_MODE:
             display = True
         timestamp = get_timestamp()
+        if var.REPORT_ERRORS:
+            _memlog[channel].append((time.monotonic(), output))
         if display:
             print(timestamp + output, file=utf8stdout)
         if write and file is not None:
@@ -55,6 +74,55 @@ def stream(output, level="normal"):
         plog(output)
     elif level in ("warning", "error"):
         plog(output)
+    elif var.REPORT_ERRORS:
+        plog(output, write=False, display=False)
 
+def get_replay(source):
+    """Retrieve the replay document."""
+    try:
+        ans = subprocess.check_output(["git", "log", "-n", "1", "--pretty=format:%h"])
+        lykosver = ans.decode()
+    except (OSError, subprocess.CalledProcessError):
+        lykosver = None
+    replay = {
+        "version": 1,
+        "timestamp": time.time(),
+        "source": source,
+        "system": {
+            "lykos": lykosver,
+            "python": platform.python_version()
+            },
+        "logs": _memlog,
+        }
+    if var.PHASE in var.GAME_PHASES:
+        # should probably split this into an event, but since we're in an exception handler,
+        # we can't necessarily guarantee that the event system is working properly
+        replay["game"] = {
+            "mode": var.CURRENT_GAMEMODE.name,
+            "count": len(var.ALL_PLAYERS),
+            "phase": var.PHASE,
+            "days": var.DAY_COUNT,
+            "nights": var.NIGHT_COUNT,
+            "status": {
+            "lycans": var.LYCANTHROPES,
+                "lucky": var.LUCKY,
+                "diseased": var.DISEASED,
+                "misdirected": var.MISDIRECTED,
+                "exchanged": var.EXCHANGED,
+                "silenced": var.SILENCED,
+                "immune": var.IMMUNIZED,
+                "protected": var.ACTIVE_PROTECTIONS
+                }
+            "players": var.ALL_PLAYERS,
+            "rolemap": {
+                "original": var.ORIGINAL_ROLES,
+                "current": var.ROLES
+                },
+            "mainroles": {
+                "original": var.ORIGINAL_MAIN_ROLES,
+                "current": var.MAIN_ROLES
+                }
+            }
+    return replay
 
 # vim: set sw=4 expandtab:

--- a/src/settings.py
+++ b/src/settings.py
@@ -213,6 +213,7 @@ LOG_PREFIX = "" # Message prefix for LOG_CHANNEL
 DEV_CHANNEL = ""
 DEV_PREFIX = ""
 PASTEBIN_ERRORS = False
+REPORT_ERRORS = False # send error reports to the developers; will include traceback as well as IRC and debug logs for context
 
 TRACEBACK_VERBOSITY = 2 # 0 = no locals at all, 1 = innermost frame's locals, 2 = all locals
 


### PR DESCRIPTION
If enabled, sends error details over to us so that we can look at them.
Includes a lot more details than the standard pastebin does, including
full IRC logs for the game as well as various game state vars that lets
us see hidden stuff more easily.

Still a work in progress, could probably be expanded to be more useful.
Compressing the data we stream over is probably not a bad idea either...