### PR TITLE
Rework misdirection and exchange

### DIFF
--- a/src/roles/_skel.py
+++ b/src/roles/_skel.py
@@ -10,7 +10,7 @@ from src.functions import get_players, get_all_players, get_main_role, get_revea
 from src.decorators import command, event_listener
 from src.containers import UserList, UserSet, UserDict, DefaultUserDict
 from src.messages import messages
-from src.events import Event
+from src.status import try_misdirection, try_exchange
 
 # Skeleton file for new roles. Not all events are represented, only the most common ones.
 
@@ -32,9 +32,15 @@ def on_chk_nightdone(evt, var):
 def on_transition_night_end(evt, var):
     pass
 
-# Update any role state that happens when someone with this role exchanges with someone else.
-@event_listener("exchange_roles")
-def on_exchange(evt, var, actor, target, actor_role, target_role):
+# Create initial role state and handle swapping roles with someone else
+# If two players have the same role and their state needs to be exchanged, don't do it here
+@event_listener("new_role")
+def on_new_role(evt, var, player, old_role):
+    pass
+
+# Swap role state for two players. Only called during an actual exchange
+@event_listener("swap_role_state")
+def on_swap_role_state(evt, var, actor, target, role):
     pass
 
 # Update any game state which happens when player dies. If this role does things upon death,

--- a/src/roles/amnesiac.py
+++ b/src/roles/amnesiac.py
@@ -10,7 +10,7 @@ from src.functions import get_players, get_all_players, get_main_role, get_revea
 from src.decorators import command, event_listener
 from src.containers import UserList, UserSet, UserDict, DefaultUserDict
 from src.messages import messages
-from src.events import Event
+from src.status import try_misdirection, try_exchange
 from src.cats import role_order, Win_Stealer
 
 ROLES = UserDict()  # type: Dict[users.User, str]

--- a/src/roles/assassin.py
+++ b/src/roles/assassin.py
@@ -11,7 +11,7 @@ from src.decorators import command, event_listener
 from src.containers import UserList, UserSet, UserDict, DefaultUserDict
 from src.messages import messages
 from src.events import Event
-from src.status import try_protection, add_dying
+from src.status import try_misdirection, try_exchange, try_protection, add_dying
 
 TARGETED = UserDict() # type: Dict[users.User, users.User]
 PREV_ACTED = UserSet()
@@ -27,14 +27,14 @@ def target(var, wrapper, message):
     if not target:
         return
 
-    evt = Event("targeted_command", {"target": target, "misdirection": True, "exchange": True})
-    if not evt.dispatch(var, wrapper.source, target):
+    orig = target
+    target = try_misdirection(var, wrapper.source, target)
+    if try_exchange(var, wrapper.source, target):
         return
-    target = evt.data["target"]
 
     TARGETED[wrapper.source] = target
 
-    wrapper.send(messages["assassin_target_success"].format(target))
+    wrapper.send(messages["assassin_target_success"].format(orig))
 
     debuglog("{0} (assassin) TARGET: {1} ({2})".format(wrapper.source, target, get_main_role(target)))
 

--- a/src/roles/augur.py
+++ b/src/roles/augur.py
@@ -8,6 +8,7 @@ from src.decorators import command, event_listener
 from src.containers import UserList, UserSet, UserDict, DefaultUserDict
 from src.functions import get_players, get_all_players, get_main_role, get_target
 from src.messages import messages
+from src.status import try_misdirection, try_exchange
 from src.events import Event
 from src.cats import Neutral, Wolfteam
 
@@ -26,11 +27,10 @@ def see(var, wrapper, message):
     if target is None:
         return
 
-    evt = Event("targeted_command", {"target": target, "misdirection": True, "exchange": True})
-    if not evt.dispatch(var, wrapper.source, target):
+    target = try_misdirection(var, wrapper.source, target)
+    if try_exchange(var, wrapper.source, target):
         return
 
-    target = evt.data["target"]
     targrole = get_main_role(target)
     trole = targrole # keep a copy for logging
 

--- a/src/roles/blessed.py
+++ b/src/roles/blessed.py
@@ -10,7 +10,7 @@ from src.functions import get_players, get_all_players
 from src.decorators import command, event_listener
 from src.containers import UserList, UserSet, UserDict, DefaultUserDict
 from src.messages import messages
-from src.events import Event
+from src.status import try_misdirection, try_exchange
 
 @event_listener("transition_night_end", priority=5)
 def on_transition_night_end(evt, var):

--- a/src/roles/clone.py
+++ b/src/roles/clone.py
@@ -10,7 +10,7 @@ from src.functions import get_players, get_all_players, get_main_role, get_revea
 from src.decorators import command, event_listener
 from src.containers import UserList, UserSet, UserDict, DefaultUserDict
 from src.messages import messages
-from src.events import Event
+from src.status import try_misdirection, try_exchange
 from src.cats import Win_Stealer
 
 CLONED = UserDict() # type: Dict[users.User, users.User]

--- a/src/roles/crazedshaman.py
+++ b/src/roles/crazedshaman.py
@@ -10,7 +10,7 @@ from src.decorators import command, event_listener
 from src.containers import UserList, UserSet, UserDict, DefaultUserDict
 from src.dispatcher import MessageDispatcher
 from src.messages import messages
-from src.events import Event
+from src.status import try_misdirection, try_exchange
 from src.cats import Win_Stealer
 
 from src.roles.helper.shamans import setup_variables, get_totem_target, give_totem

--- a/src/roles/cultist.py
+++ b/src/roles/cultist.py
@@ -10,7 +10,7 @@ from src.functions import get_players, get_all_players, get_main_role, get_revea
 from src.decorators import command, event_listener
 from src.containers import UserList, UserSet, UserDict, DefaultUserDict
 from src.messages import messages
-from src.events import Event
+from src.status import try_misdirection, try_exchange
 from src.cats import Hidden
 
 @event_listener("transition_night_end", priority=2)

--- a/src/roles/cursed.py
+++ b/src/roles/cursed.py
@@ -9,7 +9,7 @@ from src import users, channels, debuglog, errlog, plog
 from src.decorators import command, event_listener
 from src.containers import UserList, UserSet, UserDict, DefaultUserDict
 from src.messages import messages
-from src.events import Event
+from src.status import try_misdirection, try_exchange
 
 @event_listener("see")
 def on_see(evt, var, seer, target):

--- a/src/roles/demoniac.py
+++ b/src/roles/demoniac.py
@@ -10,7 +10,7 @@ from src.functions import get_players, get_all_players, get_main_role, get_revea
 from src.decorators import command, event_listener
 from src.containers import UserList, UserSet, UserDict, DefaultUserDict
 from src.messages import messages
-from src.events import Event
+from src.status import try_misdirection, try_exchange
 
 @event_listener("transition_night_end")
 def on_transition_night_end(evt, var):

--- a/src/roles/detective.py
+++ b/src/roles/detective.py
@@ -9,6 +9,7 @@ from src.functions import get_players, get_all_players, get_main_role, get_targe
 from src.decorators import command, event_listener
 from src.containers import UserList, UserSet, UserDict, DefaultUserDict
 from src.messages import messages
+from src.status import try_misdirection, try_exchange
 from src.events import Event
 from src.cats import Wolf, Wolfchat
 
@@ -25,11 +26,10 @@ def investigate(var, wrapper, message):
     if target is None:
         return
 
-    evt = Event("targeted_command", {"target": target, "misdirection": True, "exchange": True})
-    if not evt.dispatch(var, wrapper.source, target):
+    target = try_misdirection(var, wrapper.source, target)
+    if try_exchange(var, wrapper.source, target):
         return
 
-    target = evt.data["target"]
     targrole = get_main_role(target)
 
     evt = Event("investigate", {"role": targrole})

--- a/src/roles/dullahan.py
+++ b/src/roles/dullahan.py
@@ -10,7 +10,7 @@ from src.decorators import command, event_listener
 from src.containers import UserList, UserSet, UserDict, DefaultUserDict
 from src.messages import messages
 from src.events import Event
-from src.status import try_protection, add_dying
+from src.status import try_misdirection, try_exchange, try_protection, add_dying
 
 KILLS = UserDict() # type: Dict[users.User, users.User]
 TARGETS = UserDict() # type: Dict[users.User, Set[users.User]]
@@ -27,10 +27,10 @@ def dullahan_kill(var, wrapper, message):
         return
 
     orig = target
-    evt = Event("targeted_command", {"target": target, "misdirection": True, "exchange": True})
-    evt.dispatch(var, wrapper.source, target)
-    if evt.prevent_default:
+    target = try_misdirection(var, wrapper.source, target)
+    if try_exchange(var, wrapper.source, target):
         return
+
     target = evt.data["target"]
 
     KILLS[wrapper.source] = target

--- a/src/roles/fallenangel.py
+++ b/src/roles/fallenangel.py
@@ -10,7 +10,7 @@ from src.decorators import command, event_listener
 from src.containers import UserList, UserSet, UserDict, DefaultUserDict
 from src.functions import get_players, get_all_players
 from src.messages import messages
-from src.events import Event
+from src.status import try_misdirection, try_exchange
 from src.cats import Wolf
 
 from src.roles.helper.wolves import register_killer

--- a/src/roles/fool.py
+++ b/src/roles/fool.py
@@ -10,7 +10,7 @@ from src.functions import get_players, get_all_players, get_main_role, get_revea
 from src.decorators import command, event_listener
 from src.containers import UserList, UserSet, UserDict, DefaultUserDict
 from src.messages import messages
-from src.events import Event
+from src.status import try_misdirection, try_exchange
 
 VOTED = None # type: Optional[users.User]
 

--- a/src/roles/gunner.py
+++ b/src/roles/gunner.py
@@ -10,7 +10,7 @@ from src.functions import get_players, get_all_players, get_main_role, get_revea
 from src.decorators import command, event_listener
 from src.containers import UserList, UserSet, UserDict, DefaultUserDict
 from src.messages import messages
-from src.events import Event
+from src.status import try_misdirection, try_exchange
 
 from src.roles.helper.gunners import setup_variables
 

--- a/src/roles/hag.py
+++ b/src/roles/hag.py
@@ -10,7 +10,7 @@ from src.functions import get_players, get_all_players, get_main_role, get_revea
 from src.decorators import command, event_listener
 from src.containers import UserList, UserSet, UserDict, DefaultUserDict
 from src.messages import messages
-from src.events import Event
+from src.status import try_misdirection, try_exchange
 
 from src.roles.helper.wolves import is_known_wolf_ally, send_wolfchat_message
 
@@ -32,8 +32,8 @@ def hex_cmd(var, wrapper, message):
         wrapper.pm(messages["no_multiple_hex"].format(target))
         return
 
-    evt = Event("targeted_command", {"target": target, "misdirection": True, "exchange": True})
-    if not evt.dispatch(var, wrapper.source, target):
+    target = try_misdirection(var, wrapper.source, target)
+    if try_exchange(var, wrapper.source, target):
         return
 
     if is_known_wolf_ally(var, wrapper.source, target):

--- a/src/roles/harlot.py
+++ b/src/roles/harlot.py
@@ -90,6 +90,7 @@ def on_chk_nightdone(evt, var):
 @event_listener("new_role")
 def on_new_role(evt, var, player, old_role):
     if old_role == "harlot" and evt.data["role"] != "harlot":
+        PASSED.discard(player)
         if player in VISITED:
             VISITED.pop(player).send(messages["harlot_disappeared"].format(player))
 

--- a/src/roles/harlot.py
+++ b/src/roles/harlot.py
@@ -10,6 +10,7 @@ from src.functions import get_players, get_all_players, get_main_role, get_revea
 from src.decorators import command, event_listener
 from src.containers import UserList, UserSet, UserDict, DefaultUserDict
 from src.messages import messages
+from src.status import try_misdirection, try_exchange
 from src.events import Event
 from src.cats import Wolf, Wolfchat
 
@@ -27,11 +28,10 @@ def hvisit(var, wrapper, message):
     if not target:
         return
 
-    evt = Event("targeted_command", {"target": target, "misdirection": True, "exchange": True})
-    evt.dispatch(var, wrapper.source, target)
-    if evt.prevent_default:
+    target = try_misdirection(var, wrapper.source, target)
+    if try_exchange(var, wrapper.source, target):
         return
-    target = evt.data["target"]
+
     vrole = get_main_role(target)
 
     VISITED[wrapper.source] = target
@@ -87,18 +87,11 @@ def on_chk_nightdone(evt, var):
     evt.data["actedcount"] += len(VISITED) + len(PASSED)
     evt.data["nightroles"].extend(get_all_players(("harlot",)))
 
-@event_listener("exchange_roles")
-def on_exchange_roles(evt, var, actor, target, actor_role, target_role):
-    if actor_role == "harlot":
-        if actor in VISITED:
-            VISITED[actor].send(messages["harlot_disappeared"].format(actor))
-            del VISITED[actor]
-        PASSED.discard(actor)
-    if target_role == "harlot":
-        if target in VISITED:
-            VISITED[target].send(messages["harlot_disappeared"].format(target))
-            del VISITED[target]
-        PASSED.discard(target)
+@event_listener("new_role")
+def on_new_role(evt, var, player, old_role):
+    if old_role == "harlot" and evt.data["role"] != "harlot":
+        if player in VISITED:
+            VISITED.pop(player).send(messages["harlot_disappeared"].format(player))
 
 @event_listener("transition_night_end", priority=2)
 def on_transition_night_end(evt, var):

--- a/src/roles/helper/gunners.py
+++ b/src/roles/helper/gunners.py
@@ -5,7 +5,7 @@ from src.decorators import command, event_listener
 from src.containers import UserDict
 from src.functions import get_players, get_all_players, get_target, get_main_role, get_reveal_role
 from src.messages import messages
-from src.status import add_dying, kill_players, add_absent
+from src.status import try_misdirection, try_exchange, add_dying, kill_players, add_absent
 from src.events import Event
 from src.cats import Wolf, Wolfchat
 
@@ -25,12 +25,9 @@ def setup_variables(rolename):
         if not target:
             return
 
-        # get actual victim
-        evt = Event("targeted_command", {"target": target, "misdirection": True, "exchange": True})
-        if not evt.dispatch(var, wrapper.source, target):
+        target = try_misdirection(var, wrapper.source, target)
+        if try_exchange(var, wrapper.source, target):
             return
-
-        target = evt.data["target"]
 
         GUNNERS[wrapper.source] -= 1
 

--- a/src/roles/helper/mystics.py
+++ b/src/roles/helper/mystics.py
@@ -56,21 +56,14 @@ def setup_variables(rolename, *, send_role, types):
                 mystic.send(messages[to_send])
             mystic.send(msg)
 
-    @event_listener("exchange_roles")
-    def on_exchange_roles(evt, var, actor, target, actor_role, target_role):
-        if actor_role == rolename and target_role != rolename:
-            value, plural = LAST_COUNT.pop(actor)
-            LAST_COUNT[target] = (value, plural)
+    @event_listener("new_role")
+    def on_new_role(evt, var, player, old_role):
+        if evt.params.inherit_from is not None and old_role != rolename and evt.data["role"] == rolename:
+            value, plural = LAST_COUNT.pop(evt.params.inherit_from)
+            LAST_COUNT[player] = (value, plural)
             key = "were" if plural else "was"
             msg = messages["mystic_info"].format(key, value, "", messages["mystic_{0}_num".format(var.PHASE)])
-            evt.data["target_messages"].append(msg)
-
-        if target_role == rolename and actor_role != rolename:
-            value, plural = LAST_COUNT.pop(target)
-            LAST_COUNT[actor] = (value, plural)
-            key = "were" if plural else "was"
-            msg = messages["mystic_info"].format(key, value, "", messages["mystic_{0}_num".format(var.PHASE)])
-            evt.data["actor_messages"].append(msg)
+            evt.data["messages"].append(msg)
 
     @event_listener("reset")
     def on_reset(evt, var):

--- a/src/roles/helper/mystics.py
+++ b/src/roles/helper/mystics.py
@@ -58,7 +58,7 @@ def setup_variables(rolename, *, send_role, types):
 
     @event_listener("new_role")
     def on_new_role(evt, var, player, old_role):
-        if evt.params.inherit_from is not None and old_role != rolename and evt.data["role"] == rolename:
+        if evt.params.inherit_from in LAST_COUNT and old_role != rolename and evt.data["role"] == rolename:
             value, plural = LAST_COUNT.pop(evt.params.inherit_from)
             LAST_COUNT[player] = (value, plural)
             key = "were" if plural else "was"

--- a/src/roles/helper/shamans.py
+++ b/src/roles/helper/shamans.py
@@ -3,7 +3,7 @@ import random
 import re
 from collections import deque
 
-from src import channels, users, status, debuglog, errlog, plog
+from src import channels, users, debuglog, errlog, plog
 from src.functions import get_players, get_all_players, get_main_role, get_reveal_role, get_target
 from src.decorators import command, event_listener
 from src.containers import UserList, UserSet, UserDict, DefaultUserDict
@@ -202,17 +202,16 @@ def setup_variables(rolename, *, knows_totem):
 
     @event_listener("swap_role_state")
     def on_swap_role_state(evt, var, actor, target, role):
-        if role == rolename:
-            if actor in TOTEMS and target in TOTEMS:
-                TOTEMS[actor], TOTEMS[target] = TOTEMS[target], TOTEMS[actor]
-                del SHAMANS[:actor:]
-                del SHAMANS[:target:]
-                del LASTGIVEN[:actor:]
-                del LASTGIVEN[:target:]
+        if role == rolename and actor in TOTEMS and target in TOTEMS:
+            TOTEMS[actor], TOTEMS[target] = TOTEMS[target], TOTEMS[actor]
+            del SHAMANS[:actor:]
+            del SHAMANS[:target:]
+            del LASTGIVEN[:actor:]
+            del LASTGIVEN[:target:]
 
-                if knows_totem:
-                    evt.data["actor_messages"].append(messages["shaman_totem"].format(TOTEMS[actor]))
-                    evt.data["target_messages"].append(messages["shaman_totem"].format(TOTEMS[target]))
+            if knows_totem:
+                evt.data["actor_messages"].append(messages["shaman_totem"].format(TOTEMS[actor]))
+                evt.data["target_messages"].append(messages["shaman_totem"].format(TOTEMS[target]))
 
     @event_listener("default_totems", priority=3)
     def add_shaman(evt, chances):

--- a/src/roles/helper/shamans.py
+++ b/src/roles/helper/shamans.py
@@ -9,8 +9,21 @@ from src.decorators import command, event_listener
 from src.containers import UserList, UserSet, UserDict, DefaultUserDict
 from src.messages import messages
 from src.events import Event
-from src.status import add_dying, add_absent, try_protection
 from src.cats import Cursed, Safe, Innocent, Wolf, All
+from src.status import (
+    add_lycanthropy_scope,
+    add_misdirection,
+    add_lycanthropy,
+    add_protection,
+    add_exchange,
+    add_disease,
+    add_absent,
+    add_dying,
+
+    try_misdirection,
+    try_protection,
+    try_exchange,
+)
 
 #####################################################################################
 ########### ADDING CUSTOM TOTEMS AND SHAMAN ROLES TO YOUR BOT -- READ THIS ##########
@@ -176,32 +189,30 @@ def setup_variables(rolename, *, knows_totem):
             # even though retribution kills, it is given a special kill message
             evt.data[rolename] = list(TOTEMS.values()).count("death")
 
-    @event_listener("exchange_roles")
-    def on_exchange(evt, var, actor, target, actor_role, target_role):
-        actor_totem = None
-        target_totem = None
-        if actor_role == rolename:
-            actor_totem = TOTEMS.pop(actor)
-            if actor in SHAMANS:
-                del SHAMANS[actor]
-            if actor in LASTGIVEN:
-                del LASTGIVEN[actor]
+    @event_listener("new_role")
+    def on_new_role(evt, var, player, old_role):
+        if evt.params.inherit_from in TOTEMS and old_role != rolename and evt.data["role"] == rolename:
+            totem = TOTEMS.pop(evt.params.inherit_from)
+            del SHAMANS[:evt.params.inherit_from:]
+            del LASTGIVEN[:evt.params.inherit_from:]
 
-        if target_role == rolename:
-            target_totem = TOTEMS.pop(target)
-            if target in SHAMANS:
-                del SHAMANS[target]
-            if target in LASTGIVEN:
-                del LASTGIVEN[target]
+            if knows_totem:
+                evt.data["messages"].append(messages["shaman_totem"].format(totem))
+            TOTEMS[player] = totem
 
-        if target_totem:
-            if knows_totem:
-                evt.data["actor_messages"].append(messages["shaman_totem"].format(target_totem))
-            TOTEMS[actor] = target_totem
-        if actor_totem:
-            if knows_totem:
-                evt.data["target_messages"].append(messages["shaman_totem"].format(actor_totem))
-            TOTEMS[target] = actor_totem
+    @event_listener("swap_role_state")
+    def on_swap_role_state(evt, var, actor, target, role):
+        if role == rolename:
+            if actor in TOTEMS and target in TOTEMS:
+                TOTEMS[actor], TOTEMS[target] = TOTEMS[target], TOTEMS[actor]
+                del SHAMANS[:actor:]
+                del SHAMANS[:target:]
+                del LASTGIVEN[:actor:]
+                del LASTGIVEN[:target:]
+
+                if knows_totem:
+                    evt.data["actor_messages"].append(messages["shaman_totem"].format(TOTEMS[actor]))
+                    evt.data["target_messages"].append(messages["shaman_totem"].format(TOTEMS[target]))
 
     @event_listener("default_totems", priority=3)
     def add_shaman(evt, chances):
@@ -210,7 +221,7 @@ def setup_variables(rolename, *, knows_totem):
     @event_listener("transition_night_end")
     def on_transition_night_begin(evt, var):
         if get_all_players((rolename,)) and var.CURRENT_GAMEMODE.TOTEM_CHANCES["lycanthropy"][rolename] > 0:
-            status.add_lycanthropy_scope(var, All)
+            add_lycanthropy_scope(var, All)
 
     if knows_totem:
         @event_listener("myrole")
@@ -238,11 +249,10 @@ def give_totem(var, wrapper, target, prefix, role, msg):
     orig_target = target
     orig_role = get_main_role(orig_target)
 
-    evt = Event("targeted_command", {"target": target, "misdirection": True, "exchange": True})
-    if not evt.dispatch(var, wrapper.source, target):
+    target = try_misdirection(var, wrapper.source, target)
+    if try_exchange(var, wrapper.source, target):
         return
 
-    target = evt.data["target"]
     targrole = get_main_role(target)
 
     wrapper.send(messages["shaman_success"].format(prefix, msg, orig_target))
@@ -376,7 +386,7 @@ def on_transition_day3(evt, var):
     # we set priority=4.1 to allow other modes of protection
     # to pre-empt us if desired
     for player in PROTECTION:
-        status.add_protection(var, player, protector=None, protector_role="shaman")
+        add_protection(var, player, protector=None, protector_role="shaman")
 
 @event_listener("remove_protection")
 def on_remove_protection(evt, var, target, attacker, attacker_role, protector, protector_role, reason):
@@ -466,19 +476,22 @@ def on_transition_night_end(evt, var):
     # We need to add them here otherwise transition_night_begin
     # will remove them before they even get used
     for lycan in LYCANTHROPY:
-        status.add_lycanthropy(var, lycan)
+        add_lycanthropy(var, lycan)
     for pestilent in PESTILENCE:
-        status.add_disease(var, pestilent)
+        add_disease(var, pestilent)
 
 @event_listener("begin_day")
 def on_begin_day(evt, var):
     # Apply totem effects that need to begin on day proper
-    for user in NARCOLEPSY:
-        add_absent(var, user, "totem")
-    var.EXCHANGED.update(p.nick for p in EXCHANGE)
+    for absent in NARCOLEPSY:
+        add_absent(var, absent, "totem")
+    for misdirected in MISDIRECTION:
+        add_misdirection(var, misdirected, as_actor=True)
+    for lucky in LUCK:
+        add_misdirection(var, lucky, as_target=True)
+    for exchanging in EXCHANGE:
+        add_exchange(var, exchanging)
     var.SILENCED.update(p.nick for p in SILENCE)
-    var.LUCKY.update(p.nick for p in LUCK)
-    var.MISDIRECTED.update(p.nick for p in MISDIRECTION)
 
 @event_listener("player_protected")
 def on_player_protected(evt, var, target, attacker, attacker_role, protector, protector_role, reason):

--- a/src/roles/helper/wolves.py
+++ b/src/roles/helper/wolves.py
@@ -9,6 +9,7 @@ from src.functions import get_main_role, get_players, get_all_roles, get_all_pla
 from src.decorators import event_listener, command
 from src.containers import UserList, UserSet, UserDict, DefaultUserDict
 from src.messages import messages
+from src.status import try_misdirection, try_exchange
 from src.events import Event
 from src.cats import Wolf, Wolfchat, Wolfteam, Killer, Hidden
 from src import debuglog, users
@@ -51,12 +52,10 @@ def register_killer(rolename):
                 return
 
             orig.append(target)
-
-            evt = Event("targeted_command", {"target": target, "misdirection": True, "exchange": True})
-            if not evt.dispatch(var, wrapper.source, target):
+            target = try_misdirection(var, wrapper.source, target)
+            if try_exchange(var, wrapper.source, target):
                 return
 
-            target = evt.data["target"]
             targets.append(target)
 
         KILLS[wrapper.source] = UserList(targets)

--- a/src/roles/hunter.py
+++ b/src/roles/hunter.py
@@ -8,7 +8,7 @@ from src.functions import get_players, get_all_players, get_target, get_main_rol
 from src.decorators import command, event_listener
 from src.containers import UserList, UserSet, UserDict, DefaultUserDict
 from src.messages import messages
-from src.events import Event
+from src.status import try_misdirection, try_exchange
 
 KILLS = UserDict() # type: Dict[users.User, users.User]
 HUNTERS = UserSet()
@@ -25,12 +25,9 @@ def hunter_kill(var, wrapper, message):
         return
 
     orig = target
-    evt = Event("targeted_command", {"target": target, "misdirection": True, "exchange": True})
-    evt.dispatch(var, wrapper.source, target)
-    if evt.prevent_default:
+    target = try_misdirection(var, wrapper.source, target)
+    if try_exchange(var, wrapper.source, target):
         return
-
-    target = evt.data["target"]
 
     KILLS[wrapper.source] = target
     HUNTERS.add(wrapper.source)

--- a/src/roles/investigator.py
+++ b/src/roles/investigator.py
@@ -10,6 +10,7 @@ from src.functions import get_players, get_all_players, get_main_role, get_revea
 from src.decorators import command, event_listener
 from src.containers import UserList, UserSet, UserDict, DefaultUserDict
 from src.messages import messages
+from src.status import try_misdirection, try_exchange
 from src.events import Event
 from src.cats import Neutral, Wolfteam
 
@@ -37,17 +38,11 @@ def investigate(var, wrapper, message):
         wrapper.pm(messages["investigator_help"])
         return
 
-    evt = Event("targeted_command", {"target": target1, "misdirection": True, "exchange": True})
-    evt.dispatch(var, wrapper.source, target1)
-    if evt.prevent_default:
-        return
-    target1 = evt.data["target"]
+    target1 = try_misdirection(var, wrapper.source, target1)
+    target2 = try_misdirection(var, wrapper.source, target2)
 
-    evt = Event("targeted_command", {"target": target2, "misdirection": True, "exchange": True})
-    evt.dispatch(var, wrapper.source, target2)
-    if evt.prevent_default:
+    if try_exchange(var, wrapper.source, target1) or try_exchange(var, wrapper.source, target2):
         return
-    target2 = evt.data["target"]
 
     t1role = get_main_role(target1)
     t2role = get_main_role(target2)

--- a/src/roles/jester.py
+++ b/src/roles/jester.py
@@ -10,7 +10,7 @@ from src.functions import get_players, get_all_players, get_main_role, get_revea
 from src.decorators import command, event_listener
 from src.containers import UserList, UserSet, UserDict, DefaultUserDict
 from src.messages import messages
-from src.events import Event
+from src.status import try_misdirection, try_exchange
 
 JESTERS = UserSet() # type: UserSet[users.User]
 

--- a/src/roles/lycan.py
+++ b/src/roles/lycan.py
@@ -5,21 +5,21 @@ import math
 from collections import defaultdict
 
 from src.utilities import *
-from src import channels, users, status, debuglog, errlog, plog
+from src import channels, users, debuglog, errlog, plog
 from src.functions import get_players, get_all_players, get_main_role, get_reveal_role, get_target
 from src.decorators import command, event_listener
 from src.containers import UserList, UserSet, UserDict, DefaultUserDict
 from src.messages import messages
-from src.events import Event
+from src.status import try_misdirection, try_exchange, add_lycanthropy, add_lycanthropy_scope, remove_lycanthropy
 from src.cats import Wolf
 
 @event_listener("transition_night_end")
 def on_transition_night_end(evt, var):
     lycans = get_all_players(("lycan",))
     if lycans:
-        status.add_lycanthropy_scope(var, {"lycan"})
+        add_lycanthropy_scope(var, {"lycan"})
     for lycan in lycans:
-        status.add_lycanthropy(var, lycan)
+        add_lycanthropy(var, lycan)
         if lycan.prefers_simple():
             lycan.send(messages["lycan_simple"])
         else:
@@ -33,7 +33,7 @@ def on_doctor_immunize(evt, var, doctor, target):
 @event_listener("new_role")
 def on_new_role(evt, var, user, old_role):
     if old_role == "lycan" and evt.data["role"] != "lycan":
-        status.remove_lycanthropy(var, user)
+        remove_lycanthropy(var, user)
 
 # TODO: We want to remove lycan from someone who was just turned into a wolf if it was a template
 # There's no easy way to do this right now and it doesn't really matter, so it's fine for now

--- a/src/roles/madscientist.py
+++ b/src/roles/madscientist.py
@@ -10,8 +10,7 @@ from src.functions import get_players, get_all_players, get_main_role, get_revea
 from src.decorators import command, event_listener
 from src.containers import UserList, UserSet, UserDict, DefaultUserDict
 from src.messages import messages
-from src.events import Event
-from src.status import try_protection, add_dying
+from src.status import try_misdirection, try_exchange, try_protection, add_dying
 
 def _get_targets(var, pl, user):
     """Gets the mad scientist's targets.

--- a/src/roles/matchmaker.py
+++ b/src/roles/matchmaker.py
@@ -10,8 +10,7 @@ from src.functions import get_players, get_all_players, get_main_role, get_revea
 from src.decorators import command, event_listener
 from src.containers import UserList, UserSet, UserDict, DefaultUserDict
 from src.messages import messages
-from src.status import add_dying
-from src.events import Event
+from src.status import try_misdirection, try_exchange, add_dying
 from src.cats import Win_Stealer
 
 MATCHMAKERS = UserSet() # type: Set[users.User]

--- a/src/roles/mayor.py
+++ b/src/roles/mayor.py
@@ -9,7 +9,7 @@ from src import users, channels, debuglog, errlog, plog
 from src.decorators import command, event_listener
 from src.containers import UserList, UserSet, UserDict, DefaultUserDict
 from src.messages import messages
-from src.events import Event
+from src.status import try_misdirection, try_exchange
 
 REVEALED_MAYORS = UserSet()
 

--- a/src/roles/minion.py
+++ b/src/roles/minion.py
@@ -11,7 +11,7 @@ from src.functions import get_players, get_all_players, get_main_role, get_revea
 from src.decorators import command, event_listener
 from src.containers import UserList, UserSet, UserDict, DefaultUserDict
 from src.messages import messages
-from src.events import Event
+from src.status import try_misdirection, try_exchange
 from src.cats import Wolf
 
 RECEIVED_INFO = UserSet()
@@ -34,12 +34,10 @@ def on_transition_night_end(evt, var):
         minion.send(wolf_list(var))
         RECEIVED_INFO.add(minion)
 
-@event_listener("exchange_roles")
-def on_exchange(evt, var, actor, target, actor_role, target_role):
-    if actor_role == "minion":
-        evt.data["target_messages"].append(wolf_list(var))
-    elif target_role == "minion":
-        evt.data["actor_messages"].append(wolf_list(var))
+@event_listener("new_role")
+def on_new_role(evt, var, player, old_role):
+    if old_role is not None and evt.data["role"] == "minion":
+        evt.data["messages"].append(wolf_list(var))
 
 @event_listener("myrole")
 def on_myrole(evt, var, user):

--- a/src/roles/minion.py
+++ b/src/roles/minion.py
@@ -38,6 +38,7 @@ def on_transition_night_end(evt, var):
 def on_new_role(evt, var, player, old_role):
     if old_role is not None and evt.data["role"] == "minion":
         evt.data["messages"].append(wolf_list(var))
+        RECEIVED_INFO.add(player)
 
 @event_listener("myrole")
 def on_myrole(evt, var, user):

--- a/src/roles/monster.py
+++ b/src/roles/monster.py
@@ -5,12 +5,12 @@ import math
 from collections import defaultdict
 
 from src.utilities import *
-from src import channels, users, status, debuglog, errlog, plog
+from src import channels, users, debuglog, errlog, plog
 from src.functions import get_players, get_all_players, get_main_role, get_reveal_role, get_target
 from src.decorators import command, event_listener
 from src.containers import UserList, UserSet, UserDict, DefaultUserDict
 from src.messages import messages
-from src.events import Event
+from src.status import try_misdirection, try_exchange, add_protection
 from src.cats import Wolf
 
 @event_listener("player_win")
@@ -35,7 +35,7 @@ def on_chk_win(evt, var, rolemap, mainroles, lpl, lwolves, lrealwolves):
 @event_listener("transition_night_end")
 def on_transition_night_end(evt, var):
     for monster in get_all_players(("monster",)):
-        status.add_protection(var, monster, protector=None, protector_role="monster", scope=Wolf)
+        add_protection(var, monster, protector=None, protector_role="monster", scope=Wolf)
         if monster.prefers_simple():
             monster.send(messages["monster_simple"])
         else:

--- a/src/roles/mystic.py
+++ b/src/roles/mystic.py
@@ -7,7 +7,7 @@ from src.functions import get_players, get_all_players
 from src.decorators import command, event_listener
 from src.containers import UserList, UserSet, UserDict, DefaultUserDict
 from src.messages import messages
-from src.events import Event
+from src.status import try_misdirection, try_exchange
 
 from src.roles.helper.mystics import setup_variables
 

--- a/src/roles/oracle.py
+++ b/src/roles/oracle.py
@@ -8,6 +8,7 @@ from src.decorators import command, event_listener
 from src.containers import UserList, UserSet, UserDict, DefaultUserDict
 from src.functions import get_players, get_all_players, get_main_role, get_target
 from src.messages import messages
+from src.status import try_misdirection, try_exchange
 from src.events import Event
 from src.cats import Cursed, Safe, Innocent, Wolf
 
@@ -26,11 +27,10 @@ def see(var, wrapper, message):
     if target is None:
         return
 
-    evt = Event("targeted_command", {"target": target, "misdirection": True, "exchange": True})
-    if not evt.dispatch(var, wrapper.source, target):
+    target = try_misdirection(var, wrapper.source, target)
+    if try_exchange(var, wrapper.source):
         return
 
-    target = evt.data["target"]
     targrole = get_main_role(target)
     trole = targrole # keep a copy for logging
 

--- a/src/roles/priest.py
+++ b/src/roles/priest.py
@@ -11,7 +11,7 @@ from src.decorators import command, event_listener
 from src.containers import UserList, UserSet, UserDict, DefaultUserDict
 from src.messages import messages
 from src.events import Event
-from src.status import add_absent
+from src.status import try_misdirection, try_exchange, add_absent
 
 PRIESTS = UserSet() # type: Set[users.User]
 
@@ -26,8 +26,8 @@ def bless(var, wrapper, message):
     if not target:
         return
 
-    evt = Event("targeted_command", {"target": target, "exchange": True, "misdirection": True})
-    if not evt.dispatch(var, wrapper.source, target):
+    target = try_misdirection(var, wrapper.source, target)
+    if try_exchange(var, wrapper.source, target):
         return
 
     PRIESTS.add(wrapper.source)

--- a/src/roles/prophet.py
+++ b/src/roles/prophet.py
@@ -10,7 +10,7 @@ from src.functions import get_players, get_all_players, get_main_role, get_revea
 from src.decorators import command, event_listener
 from src.containers import UserList, UserSet, UserDict, DefaultUserDict
 from src.messages import messages
-from src.events import Event
+from src.status import try_misdirection, try_exchange
 
 PRAYED = UserSet() # type: Set[users.User]
 

--- a/src/roles/seer.py
+++ b/src/roles/seer.py
@@ -9,6 +9,7 @@ from src.containers import UserList, UserSet, UserDict, DefaultUserDict
 from src.functions import get_players, get_all_players, get_main_role, get_target
 from src.messages import messages
 from src.events import Event
+from src.status import try_misdirection, try_exchange
 from src.cats import Cursed, Safe, Innocent, Wolf
 
 from src.roles.helper.seers import setup_variables
@@ -26,11 +27,10 @@ def see(var, wrapper, message):
     if target is None:
         return
 
-    evt = Event("targeted_command", {"target": target, "misdirection": True, "exchange": True})
-    if not evt.dispatch(var, wrapper.source, target):
+    target = try_misdirection(var, wrapper.source, target)
+    if try_exchange(var, wrapper.source, target):
         return
 
-    target = evt.data["target"]
     targrole = get_main_role(target)
     trole = targrole # keep a copy for logging
 

--- a/src/roles/shaman.py
+++ b/src/roles/shaman.py
@@ -10,7 +10,7 @@ from src.decorators import command, event_listener
 from src.containers import UserList, UserSet, UserDict, DefaultUserDict
 from src.dispatcher import MessageDispatcher
 from src.messages import messages
-from src.events import Event
+from src.status import try_misdirection, try_exchange
 
 from src.roles.helper.shamans import setup_variables, get_totem_target, give_totem
 

--- a/src/roles/sharpshooter.py
+++ b/src/roles/sharpshooter.py
@@ -10,7 +10,7 @@ from src.functions import get_players, get_all_players, get_main_role, get_revea
 from src.decorators import command, event_listener
 from src.containers import UserList, UserSet, UserDict, DefaultUserDict
 from src.messages import messages
-from src.events import Event
+from src.status import try_misdirection, try_exchange
 
 from src.roles.helper.gunners import setup_variables
 

--- a/src/roles/sorcerer.py
+++ b/src/roles/sorcerer.py
@@ -10,7 +10,7 @@ from src.functions import get_players, get_all_players, get_main_role, get_revea
 from src.decorators import command, event_listener
 from src.containers import UserList, UserSet, UserDict, DefaultUserDict
 from src.messages import messages
-from src.events import Event
+from src.status import try_misdirection, try_exchange
 from src.cats import Spy
 
 from src.roles.helper.wolves import is_known_wolf_ally, send_wolfchat_message
@@ -32,11 +32,9 @@ def observe(var, wrapper, message):
         wrapper.pm(messages["no_observe_wolf"])
         return
 
-    evt = Event("targeted_command", {"target": target, "exchange": True, "misdirection": True})
-    if not evt.dispatch(var, wrapper.source, target):
+    target = try_misdirection(var, wrapper.source, target)
+    if try_exchange(var, wrapper.source, target):
         return
-
-    target = evt.data["target"]
 
     OBSERVED.add(wrapper.source)
     targrole = get_main_role(target)

--- a/src/roles/timelord.py
+++ b/src/roles/timelord.py
@@ -12,7 +12,7 @@ from src.functions import get_players, get_all_players, get_main_role, get_revea
 from src.decorators import command, event_listener
 from src.containers import UserList, UserSet, UserDict, DefaultUserDict
 from src.messages import messages
-from src.events import Event
+from src.status import try_misdirection, try_exchange
 
 TIME_ATTRIBUTES = (
     ("DAY_TIME_LIMIT", "TIME_LORD_DAY_LIMIT"),

--- a/src/roles/traitor.py
+++ b/src/roles/traitor.py
@@ -9,6 +9,7 @@ from src import debuglog, errlog, plog, users, channels
 from src.decorators import command, event_listener
 from src.containers import UserList, UserSet, UserDict, DefaultUserDict
 from src.messages import messages
+from src.status import try_misdirection, try_exchange
 from src.events import Event
 
 @event_listener("get_reveal_role")

--- a/src/roles/turncoat.py
+++ b/src/roles/turncoat.py
@@ -10,7 +10,7 @@ from src.functions import get_players, get_all_players, get_main_role, get_revea
 from src.decorators import command, event_listener
 from src.containers import UserList, UserSet, UserDict, DefaultUserDict
 from src.messages import messages
-from src.events import Event
+from src.status import try_misdirection, try_exchange
 
 TURNCOATS = UserDict() # type: Dict[users.User, Tuple[str, int]]
 PASSED = UserSet() # type: Set[users.User]

--- a/src/roles/vengefulghost.py
+++ b/src/roles/vengefulghost.py
@@ -8,7 +8,7 @@ from src.functions import get_players, get_target, get_main_role
 from src.decorators import command, event_listener
 from src.containers import UserList, UserSet, UserDict, DefaultUserDict
 from src.messages import messages
-from src.events import Event
+from src.status import try_misdirection, try_exchange
 from src.cats import All, Wolfteam
 
 KILLS = UserDict() # type: Dict[users.User, users.User]
@@ -40,11 +40,7 @@ def vg_kill(var, wrapper, message):
         return
 
     orig = target
-    evt = Event("targeted_command", {"target": target, "misdirection": True, "exchange": False})
-    evt.dispatch(var, wrapper.source, target)
-    if evt.prevent_default:
-        return
-    target = evt.data["target"]
+    target = try_misdirection(var, wrapper.source, target)
 
     KILLS[wrapper.source] = target
 

--- a/src/roles/vigilante.py
+++ b/src/roles/vigilante.py
@@ -17,7 +17,6 @@ PASSED = UserSet() # type: Set[users.User]
 @command("kill", chan=False, pm=True, playing=True, silenced=True, phases=("night",), roles=("vigilante",))
 def vigilante_kill(var, wrapper, message):
     """Kill someone at night, but you die too if they aren't a wolf or win stealer!"""
-
     target = get_target(var, wrapper, re.split(" +", message)[0], not_self_message="no_suicide")
 
     orig = target

--- a/src/roles/vigilante.py
+++ b/src/roles/vigilante.py
@@ -8,8 +8,7 @@ from src.functions import get_players, get_all_players, get_main_role, get_targe
 from src.decorators import command, event_listener
 from src.containers import UserList, UserSet, UserDict, DefaultUserDict
 from src.messages import messages
-from src.events import Event
-from src.status import add_dying
+from src.status import try_misdirection, try_exchange, add_dying
 from src.cats import Wolf, Win_Stealer
 
 KILLS = UserDict() # type: Dict[users.User, users.User]
@@ -22,11 +21,9 @@ def vigilante_kill(var, wrapper, message):
     target = get_target(var, wrapper, re.split(" +", message)[0], not_self_message="no_suicide")
 
     orig = target
-    evt = Event("targeted_command", {"target": target, "misdirection": True, "exchange": True})
-    evt.dispatch(var, wrapper.source, target)
-    if evt.prevent_default:
+    target = try_misdirection(var, wrapper.source, target)
+    if try_exchange(var, wrapper.source, target):
         return
-    target = evt.data["target"]
 
     KILLS[wrapper.source] = target
     PASSED.discard(wrapper.source)

--- a/src/roles/villagedrunk.py
+++ b/src/roles/villagedrunk.py
@@ -10,7 +10,7 @@ from src.functions import get_players, get_all_players, get_main_role, get_revea
 from src.decorators import command, event_listener
 from src.containers import UserList, UserSet, UserDict, DefaultUserDict
 from src.messages import messages
-from src.events import Event
+from src.status import try_misdirection, try_exchange
 
 @event_listener("transition_night_end")
 def on_transition_night_end(evt, var):

--- a/src/roles/villager.py
+++ b/src/roles/villager.py
@@ -4,7 +4,7 @@ from src.functions import get_players
 from src.decorators import command, event_listener
 from src.containers import UserList, UserSet, UserDict, DefaultUserDict
 from src.messages import messages
-from src.events import Event
+from src.status import try_misdirection, try_exchange
 from src.cats import Hidden
 
 @event_listener("transition_night_end", priority=2)

--- a/src/roles/warlock.py
+++ b/src/roles/warlock.py
@@ -10,7 +10,7 @@ from src.functions import get_players, get_all_players, get_main_role, get_revea
 from src.decorators import command, event_listener
 from src.containers import UserList, UserSet, UserDict, DefaultUserDict
 from src.messages import messages
-from src.events import Event
+from src.status import try_misdirection, try_exchange
 
 from src.roles.helper.wolves import get_wolfchat_roles, is_known_wolf_ally, send_wolfchat_message
 
@@ -35,17 +35,18 @@ def curse(var, wrapper, message):
         wrapper.pm(messages["no_curse_wolf"])
         return
 
-    evt = Event("targeted_command", {"target": target, "exchange": True, "misdirection": True})
-    if not evt.dispatch(var, wrapper.source, target):
+    orig = target
+    target = try_misdirection(var, wrapper.source, target)
+    if try_exchange(var, wrapper.source, target):
         return
 
-    CURSED[wrapper.source] = evt.data["target"]
+    CURSED[wrapper.source] = target
     PASSED.discard(wrapper.source)
 
-    wrapper.pm(messages["curse_success"].format(target))
-    send_wolfchat_message(var, wrapper.source, messages["curse_success_wolfchat"].format(wrapper.source, target), {"warlock"}, role="warlock", command="curse")
+    wrapper.pm(messages["curse_success"].format(orig))
+    send_wolfchat_message(var, wrapper.source, messages["curse_success_wolfchat"].format(wrapper.source, orig), {"warlock"}, role="warlock", command="curse")
 
-    debuglog("{0} (warlock) CURSE: {1} ({2})".format(wrapper.source, evt.data["target"], get_main_role(evt.data["target"])))
+    debuglog("{0} (warlock) CURSE: {1} ({2})".format(wrapper.source, target, get_main_role(target)))
 
 @command("pass", chan=False, pm=True, playing=True, silenced=True, phases=("night",), roles=("warlock",))
 def pass_cmd(var, wrapper, message):

--- a/src/roles/werecrow.py
+++ b/src/roles/werecrow.py
@@ -7,7 +7,7 @@ from src.functions import get_players, get_all_players, get_all_roles, get_targe
 from src.decorators import command, event_listener
 from src.containers import UserList, UserSet, UserDict, DefaultUserDict
 from src.messages import messages
-from src.events import Event
+from src.status import try_misdirection, try_exchange
 from src.cats import Nocturnal
 from src.roles.helper.wolves import is_known_wolf_ally, send_wolfchat_message, register_killer
 
@@ -29,12 +29,10 @@ def observe(var, wrapper, message):
         return
 
     orig = target
-    evt = Event("targeted_command", {"target": target, "misdirection": True, "exchange": True})
-    evt.dispatch(var, wrapper.source, target)
-    if evt.prevent_default:
+    target = try_misdirection(var, wrapper.source, target)
+    if try_exchange(var, wrapper.source, target):
         return
 
-    target = evt.data["target"]
     OBSERVED[wrapper.source] = target
     wrapper.pm(messages["werecrow_observe_success"].format(orig))
     send_wolfchat_message(var, wrapper.source, messages["wolfchat_observe"].format(wrapper.source, target), {"werecrow"}, role="werecrow", command="observe")

--- a/src/roles/werekitten.py
+++ b/src/roles/werekitten.py
@@ -10,7 +10,7 @@ from src.functions import get_players, get_all_players, get_main_role, get_revea
 from src.decorators import command, event_listener
 from src.containers import UserList, UserSet, UserDict, DefaultUserDict
 from src.messages import messages
-from src.events import Event
+from src.status import try_misdirection, try_exchange
 from src.roles.helper.wolves import register_killer
 
 register_killer("werekitten")

--- a/src/roles/wildchild.py
+++ b/src/roles/wildchild.py
@@ -6,13 +6,14 @@ from collections import defaultdict
 
 from src.utilities import *
 from src import channels, users, debuglog, errlog, plog
-from src.functions import get_players, get_all_players, get_main_role, get_reveal_role, get_target, change_role
+from src.functions import get_players, get_all_players, get_main_role, get_reveal_role, get_all_roles, get_target, change_role
 from src.decorators import command, event_listener
 from src.containers import UserList, UserSet, UserDict, DefaultUserDict
 from src.messages import messages
-from src.events import Event
+from src.status import try_misdirection, try_exchange
 
-WILD_CHILDREN = UserSet()
+from src.roles.helper.wolves import get_wolfchat_roles
+
 IDOLS = UserDict()
 
 @command("choose", chan=False, pm=True, playing=True, phases=("night",), roles=("wild child",))
@@ -32,33 +33,37 @@ def choose_idol(var, wrapper, message):
 
 @event_listener("see")
 def on_see(evt, var, seer, target):
-    if target in WILD_CHILDREN:
+    if target in get_all_players(("wild child",)):
         evt.data["role"] = "wild child"
 
-@event_listener("exchange_roles")
-def on_exchange(evt, var, actor, target, actor_role, target_role):
-    if actor_role == "wolf" and actor in WILD_CHILDREN and target not in WILD_CHILDREN:
-        WILD_CHILDREN.discard(actor)
-        WILD_CHILDREN.add(target)
-    elif actor_role == "wild child":
-        if target_role == "wild child":
-            IDOLS[actor], IDOLS[target] = IDOLS[target], IDOLS[actor]
+@event_listener("new_role")
+def on_new_role(evt, var, user, old_role):
+    if evt.data["role"] == "wolf" and old_role == "wild child" and evt.params.inherit_from and "wild child" in get_all_roles(evt.params.inherit_from):
+        evt.data["role"] = "wild child"
+
+    if evt.params.inherit_from in IDOLS and old_role != "wild child" and evt.data["role"] == "wild child":
+        IDOLS[user] = IDOLS.pop(evt.params.inherit_from)
+        evt.data["messages"].append(messages["wild_child_idol"].format(IDOLS[user]))
+
+@event_listener("swap_role_state")
+def on_swap_role_state(evt, var, actor, target, role):
+    if role == "wild child":
+        IDOLS[actor], IDOLS[target] = IDOLS[target], IDOLS[user]
+        if IDOLS[actor] in get_players():
             evt.data["actor_messages"].append(messages["wild_child_idol"].format(IDOLS[actor]))
+        else: # The King is dead, long live the King!
+            change_role(var, actor, "wild child", "wolf", message="wild_child_idol_died")
+            var.ROLES["wild child"].add(actor)
+
+        if IDOLS[target] in get_players():
             evt.data["target_messages"].append(messages["wild_child_idol"].format(IDOLS[target]))
         else:
-            IDOLS[target] = IDOLS.pop(actor)
-            evt.data["target_messages"].append(messages["wild_child_idol"].format(IDOLS[target]))
-    if target_role == "wolf" and target in WILD_CHILDREN and actor not in WILD_CHILDREN:
-        WILD_CHILDREN.discard(target)
-        WILD_CHILDREN.add(actor)
-    elif target_role == "wild child" and actor_role != "wild child":
-        # if they're both wild children, already swapped idols above
-        IDOLS[actor] = IDOLS.pop(target)
-        evt.data["actor_messages"].append(messages["wild_child_idol"].format(IDOLS[actor]))
+            change_role(var, target, "wild child", "wolf", message="wild_child_idol_died")
+            var.ROLES["wild child"].add(target)
 
 @event_listener("myrole")
 def on_myrole(evt, var, user):
-    if user in IDOLS:
+    if user in IDOLS and user not in get_players(get_wolfchat_roles(var)):
         evt.data["messages"].append(messages["wild_child_idol"].format(IDOLS[user]))
 
 @event_listener("del_player")
@@ -70,9 +75,8 @@ def on_del_player(evt, var, player, all_roles, death_triggers):
     for child in get_all_players(("wild child",)):
         if IDOLS.get(child) is player:
             # Change their main role to wolf
-            WILD_CHILDREN.add(child)
             change_role(var, child, get_main_role(child), "wolf", message="wild_child_idol_died")
-            var.ROLES["wild child"].discard(child)
+            var.ROLES["wild child"].add(child)
 
 @event_listener("chk_nightdone")
 def on_chk_nightdone(evt, var):
@@ -95,7 +99,10 @@ def on_transition_day_begin(evt, var):
 
 @event_listener("transition_night_end", priority=2)
 def on_transition_night_end(evt, var):
+    wolves = get_players(get_wolfchat_roles(var))
     for child in get_all_players(("wild child",)):
+        if child in wolves:
+            continue
         if child.prefers_simple():
             child.send(messages["wild_child_simple"])
         else:
@@ -103,7 +110,7 @@ def on_transition_night_end(evt, var):
 
 @event_listener("revealroles_role")
 def on_revealroles_role(evt, var, user, role):
-    if role == "wild child":
+    if role == "wild child" and user not in get_players(get_wolfchat_roles(var)):
         if user in IDOLS:
             evt.data["special_case"].append(messages["wild_child_revealroles_picked"].format(IDOLS[user]))
         else:
@@ -111,12 +118,11 @@ def on_revealroles_role(evt, var, user, role):
 
 @event_listener("get_reveal_role")
 def on_get_reveal_role(evt, var, user):
-    if user in WILD_CHILDREN:
+    if user in get_all_players(("wild child",)):
         evt.data["role"] = "wild child"
 
 @event_listener("reset")
 def on_reset(evt, var):
-    WILD_CHILDREN.clear()
     IDOLS.clear()
 
 @event_listener("get_role_metadata")

--- a/src/roles/wildchild.py
+++ b/src/roles/wildchild.py
@@ -41,14 +41,14 @@ def on_new_role(evt, var, user, old_role):
     if evt.data["role"] == "wolf" and old_role == "wild child" and evt.params.inherit_from and "wild child" in get_all_roles(evt.params.inherit_from):
         evt.data["role"] = "wild child"
 
-    if evt.params.inherit_from in IDOLS and old_role != "wild child" and evt.data["role"] == "wild child":
+    if evt.params.inherit_from in IDOLS and "wild child" not in get_all_roles(user):
         IDOLS[user] = IDOLS.pop(evt.params.inherit_from)
         evt.data["messages"].append(messages["wild_child_idol"].format(IDOLS[user]))
 
 @event_listener("swap_role_state")
 def on_swap_role_state(evt, var, actor, target, role):
     if role == "wild child":
-        IDOLS[actor], IDOLS[target] = IDOLS[target], IDOLS[user]
+        IDOLS[actor], IDOLS[target] = IDOLS[target], IDOLS[actor]
         if IDOLS[actor] in get_players():
             evt.data["actor_messages"].append(messages["wild_child_idol"].format(IDOLS[actor]))
         else: # The King is dead, long live the King!

--- a/src/roles/wolfcub.py
+++ b/src/roles/wolfcub.py
@@ -8,7 +8,7 @@ from src import debuglog, errlog, plog, users, channels
 from src.decorators import command, event_listener
 from src.containers import UserList, UserSet, UserDict, DefaultUserDict
 from src.messages import messages
-from src.events import Event
+from src.status import try_misdirection, try_exchange
 from src.cats import Wolf, Killer
 
 from src.roles.helper.wolves import wolf_can_kill

--- a/src/roles/wolfmystic.py
+++ b/src/roles/wolfmystic.py
@@ -7,7 +7,7 @@ from src.functions import get_players, get_all_players
 from src.decorators import command, event_listener
 from src.containers import UserList, UserSet, UserDict, DefaultUserDict
 from src.messages import messages
-from src.events import Event
+from src.status import try_misdirection, try_exchange
 
 from src.roles.helper.mystics import setup_variables
 from src.roles.helper.wolves import register_killer

--- a/src/roles/wolfshaman.py
+++ b/src/roles/wolfshaman.py
@@ -10,7 +10,7 @@ from src.decorators import command, event_listener
 from src.containers import UserList, UserSet, UserDict, DefaultUserDict
 from src.dispatcher import MessageDispatcher
 from src.messages import messages
-from src.events import Event
+from src.status import try_misdirection, try_exchange
 
 from src.roles.helper.shamans import get_totem_target, give_totem, setup_variables
 from src.roles.helper.wolves import register_killer

--- a/src/status/exchange.py
+++ b/src/status/exchange.py
@@ -17,11 +17,11 @@ def try_exchange(var, actor, target):
 
     EXCHANGE.remove(target)
 
-    actor_role = get_main_role(actor)
+    role = get_main_role(actor)
     target_role = get_main_role(target)
 
-    actor_role = change_role(var, actor, actor_role, target_role, inherit_from=target)
-    target_role = change_role(var, target, target_role, actor_role, inherit_from=actor)
+    actor_role = change_role(var, actor, role, target_role, inherit_from=target)
+    target_role = change_role(var, target, target_role, role, inherit_from=actor)
 
     if actor_role == target_role: # swap state of two players with the same role
         evt = Event("swap_role_state", {"actor_messages": [], "target_messages": []})
@@ -31,6 +31,10 @@ def try_exchange(var, actor, target):
         target.send(*evt.data["target_messages"])
 
     return True
+
+@event_listener("del_player")
+def on_del_player(evt, var, player, allroles, death_triggers):
+    EXCHANGE.discard(player)
 
 @event_listener("revealroles")
 def on_revealroles(evt, var, wrapper):

--- a/src/status/exchange.py
+++ b/src/status/exchange.py
@@ -1,0 +1,46 @@
+from src.containers import UserSet
+from src.decorators import event_listener
+from src.functions import get_main_role, change_role
+from src.events import Event
+
+__all__ = ["add_exchange", "try_exchange"]
+
+EXCHANGE = UserSet() # type: Set[users.User]
+
+def add_exchange(var, user):
+    EXCHANGE.add(user)
+
+def try_exchange(var, actor, target):
+    """Check if an exchange is happening. Return True if the exchange occurs."""
+    if actor is target or target not in EXCHANGE:
+        return False
+
+    EXCHANGE.remove(target)
+
+    actor_role = get_main_role(actor)
+    target_role = get_main_role(target)
+
+    actor_role = change_role(var, actor, actor_role, target_role, inherit_from=target)
+    target_role = change_role(var, target, target_role, actor_role, inherit_from=actor)
+
+    if actor_role == target_role: # swap state of two players with the same role
+        evt = Event("swap_role_state", {"actor_messages": [], "target_messages": []})
+        evt.dispatch(var, actor, target, actor_role)
+
+        actor.send(*evt.data["actor_messages"])
+        target.send(*evt.data["target_messages"])
+
+    return True
+
+@event_listener("revealroles")
+def on_revealroles(evt, var, wrapper):
+    if EXCHANGE:
+        evt.data["output"].append("\u0002exchange\u0002: {0}".format(", ".join(p.nick for p in EXCHANGE)))
+
+@event_listener("transition_day_begin")
+def on_transition_day_begin(evt, var):
+    EXCHANGE.clear()
+
+@event_listener("reset")
+def on_reset(evt, var):
+    EXCHANGE.clear()

--- a/src/status/misdirection.py
+++ b/src/status/misdirection.py
@@ -30,6 +30,11 @@ def try_misdirection(var, actor, target):
 
     return target
 
+@event_listener("del_player")
+def on_del_player(evt, var, player, allroles, death_triggers):
+    MISDIRECTED.discard(player)
+    LUCKY.discard(player)
+
 @event_listener("revealroles")
 def on_revealroles(evt, var, wrapper):
     if MISDIRECTED or LUCKY:

--- a/src/status/misdirection.py
+++ b/src/status/misdirection.py
@@ -6,8 +6,8 @@ from src.functions import get_players
 
 __all__ = ["add_misdirection", "try_misdirection"]
 
-MISDIRECTED = UserSet() # type: Set[users.User]
-LUCKY = UserSet() # type: Set[users.User]
+AS_ACTOR = UserSet() # type: Set[users.User]
+AS_TARGET = UserSet() # type: Set[users.User]
 
 def _get_target(target):
     """Internal helper for try_misdirection. Return one target overt."""
@@ -21,44 +21,44 @@ def _get_target(target):
 
 def add_misdirection(var, user, *, as_actor=False, as_target=False):
     if as_actor:
-        MISDIRECTED.add(user)
+        AS_ACTOR.add(user)
     if as_target:
-        LUCKY.add(user)
+        AS_TARGET.add(user)
 
 def try_misdirection(var, actor, target):
     """Check if misdirection can apply. Return the target."""
     if actor is not target:
-        if actor in MISDIRECTED:
+        if actor in AS_ACTOR:
             target = _get_target(target)
-        if target in LUCKY:
+        if target in AS_TARGET:
             target = _get_target(target)
     return target
 
 @event_listener("del_player")
 def on_del_player(evt, var, player, allroles, death_triggers):
-    MISDIRECTED.discard(player)
-    LUCKY.discard(player)
+    AS_ACTOR.discard(player)
+    AS_TARGET.discard(player)
 
 @event_listener("revealroles")
 def on_revealroles(evt, var, wrapper):
-    if MISDIRECTED or LUCKY:
-        misdirected = MISDIRECTED | LUCKY
+    if AS_ACTOR or AS_TARGET:
+        misdirected = AS_ACTOR | AS_TARGET
         out = []
         for user in misdirected:
             as_what = []
-            if user in MISDIRECTED:
+            if user in AS_ACTOR:
                 as_what.append("actor")
-            if user in LUCKY:
+            if user in AS_TARGET:
                 as_what.append("target")
             out.append("{0} (as {1})".format(user, " and ".join(as_what)))
         evt.data["output"].append("\u0002misdirected\u0002: {0}".format(", ".join(out)))
 
 @event_listener("transition_day_begin")
 def on_transition_day_begin(evt, var):
-    MISDIRECTED.clear()
-    LUCKY.clear()
+    AS_ACTOR.clear()
+    AS_TARGET.clear()
 
 @event_listener("reset")
 def on_reset(evt, var):
-    MISDIRECTED.clear()
-    LUCKY.clear()
+    AS_ACTOR.clear()
+    AS_TARGET.clear()

--- a/src/status/misdirection.py
+++ b/src/status/misdirection.py
@@ -9,6 +9,16 @@ __all__ = ["add_misdirection", "try_misdirection"]
 MISDIRECTED = UserSet() # type: Set[users.User]
 LUCKY = UserSet() # type: Set[users.User]
 
+def _get_target(target):
+    """Internal helper for try_misdirection. Return one target overt."""
+    pl = get_players()
+    index = pl.index(target)
+    if random.randint(0, 1):
+        index -= 2
+    if index == len(pl) - 1: # last item
+        index = -1
+    return pl[index+1]
+
 def add_misdirection(var, user, *, as_actor=False, as_target=False):
     if as_actor:
         MISDIRECTED.add(user)
@@ -17,17 +27,11 @@ def add_misdirection(var, user, *, as_actor=False, as_target=False):
 
 def try_misdirection(var, actor, target):
     """Check if misdirection can apply. Return the target."""
-    # If the actor is misdirected but the target is lucky, they cancel each other out
-    # If we did it sequencially, there'd be a chance of targeting the second neighbor
-    if actor is not target and (actor in MISDIRECTED) ^ (target in LUCKY):
-        pl = get_players()
-        index = pl.index(target)
-        if random.randint(0, 1):
-            index -= 2
-        if index == len(pl) - 1: # last item
-            index = -1
-        target = pl[index+1]
-
+    if actor is not target:
+        if actor in MISDIRECTED:
+            target = _get_target(target)
+        if target in LUCKY:
+            target = _get_target(target)
     return target
 
 @event_listener("del_player")

--- a/src/status/misdirection.py
+++ b/src/status/misdirection.py
@@ -1,0 +1,55 @@
+import random
+
+from src.decorators import event_listener
+from src.containers import UserSet
+from src.functions import get_players
+
+__all__ = ["add_misdirection", "try_misdirection"]
+
+MISDIRECTED = UserSet() # type: Set[users.User]
+LUCKY = UserSet() # type: Set[users.User]
+
+def add_misdirection(var, user, *, as_actor=False, as_target=False):
+    if as_actor:
+        MISDIRECTED.add(user)
+    if as_target:
+        LUCKY.add(user)
+
+def try_misdirection(var, actor, target):
+    """Check if misdirection can apply. Return the target."""
+    # If the actor is misdirected but the target is lucky, they cancel each other out
+    # If we did it sequencially, there'd be a chance of targeting the second neighbor
+    if actor is not target and (actor in MISDIRECTED) ^ (target in LUCKY):
+        pl = get_players()
+        index = pl.index(target)
+        if random.randint(0, 1):
+            index -= 2
+        if index == len(pl) - 1: # last item
+            index = -1
+        target = pl[index+1]
+
+    return target
+
+@event_listener("revealroles")
+def on_revealroles(evt, var, wrapper):
+    if MISDIRECTED or LUCKY:
+        misdirected = MISDIRECTED | LUCKY
+        out = []
+        for user in misdirected:
+            as_what = []
+            if user in MISDIRECTED:
+                as_what.append("actor")
+            if user in LUCKY:
+                as_what.append("target")
+            out.append("{0} (as {1})".format(user, " and ".join(as_what)))
+        evt.data["output"].append("\u0002misdirected\u0002: {0}".format(", ".join(out)))
+
+@event_listener("transition_day_begin")
+def on_transition_day_begin(evt, var):
+    MISDIRECTED.clear()
+    LUCKY.clear()
+
+@event_listener("reset")
+def on_reset(evt, var):
+    MISDIRECTED.clear()
+    LUCKY.clear()

--- a/src/wolfgame.py
+++ b/src/wolfgame.py
@@ -2211,16 +2211,7 @@ def rename_player(var, user, prefix):
             for dictvar in (var.FINAL_ROLES,):
                 if prefix in dictvar.keys():
                     dictvar[nick] = dictvar.pop(prefix)
-            for idx, tup in enumerate(var.EXCHANGED_ROLES):
-                a, b = tup
-                if a == prefix:
-                    a = nick
-                if b == prefix:
-                    b = nick
-                var.EXCHANGED_ROLES[idx] = (a, b)
-
-            for setvar in (var.SILENCED, var.LUCKY,
-                           var.MISDIRECTED, var.EXCHANGED):
+            for setvar in (var.SILENCED,):
                 if prefix in setvar:
                     setvar.remove(prefix)
                     setvar.add(nick)
@@ -2420,9 +2411,6 @@ def begin_day():
     var.KILLER = ""  # nickname of who chose the victim
     var.STARTED_DAY_PLAYERS = len(list_players())
     var.SILENCED = set()
-    var.EXCHANGED = set()
-    var.LUCKY = set()
-    var.MISDIRECTED = set()
     var.LAST_GOAT.clear()
     msg = messages["villagers_lynch"].format(botconfig.CMD_CHAR, len(list_players()) // 2 + 1)
     channels.Main.send(msg)
@@ -2780,89 +2768,6 @@ def lynch(var, wrapper, message):
 
     chk_decision()
 
-# chooses a target given nick, taking luck totem/misdirection totem into effect
-# returns the actual target
-def choose_target(actor, nick):
-    pl = list_players()
-    if actor in var.MISDIRECTED:
-        for i, user in enumerate(var.ALL_PLAYERS):
-            if user.nick == nick:
-                break
-        if random.randint(0, 1) == 0:
-            # going left
-            while True:
-                i -= 1
-                if var.ALL_PLAYERS[i].nick in pl:
-                    nick = var.ALL_PLAYERS[i].nick
-                    break
-        else:
-            # going right
-            while True:
-                i += 1
-                if i >= len(var.ALL_PLAYERS):
-                    i = 0
-                if var.ALL_PLAYERS[i].nick in pl:
-                    nick = var.ALL_PLAYERS[i].nick
-                    break
-    if nick in var.LUCKY:
-        for i, user in enumerate(var.ALL_PLAYERS):
-            if user.nick == nick:
-                break
-        if random.randint(0, 1) == 0:
-            # going left
-            while True:
-                i -= 1
-                if var.ALL_PLAYERS[i].nick in pl:
-                    nick = var.ALL_PLAYERS[i].nick
-                    break
-        else:
-            # going right
-            while True:
-                i += 1
-                if i >= len(var.ALL_PLAYERS):
-                    i = 0
-                if var.ALL_PLAYERS[i].nick in pl:
-                    nick = var.ALL_PLAYERS[i].nick
-                    break
-    return nick
-
-# returns true if a swap happened
-# check for that to short-circuit the nightrole
-def check_exchange(cli, actor, nick):
-    # July 2nd, 2018 - The exchanging mechanic has been updated and no longer handles
-    # some forms of exchanging properly. As a result, we are disabling exchanging until
-    # role classes are implemented, which needs all roles to be fully split first.
-    # Until then, this function is a no-op. -Vgr & woffle
-    return False
-    #some roles can act on themselves, ignore this
-    if actor == nick:
-        return False
-
-    user = users._get(actor) # FIXME
-    target = users._get(nick) # FIXME
-
-    if nick in var.EXCHANGED:
-        var.EXCHANGED.remove(nick)
-        actor_role = get_role(actor)
-        nick_role = get_role(nick)
-
-        evt = Event("exchange_roles", {"actor_messages": [], "target_messages": [], "actor_role": actor_role, "target_role": nick_role})
-        evt.dispatch(var, user, target, actor_role, nick_role) # FIXME: Deprecated, change in favor of new_role and swap_role_state
-
-        nick_role = change_role(var, user, actor_role, nick_role, inherit_from=target)
-        actor_role = change_role(var, target, nick_role, actor_role, inherit_from=user)
-
-        if nick_role == actor_role: # make sure that two players with the same role exchange their role state properly (e.g. dullahan)
-            evt_same = Event("swap_role_state", {"actor_messages": [], "target_messages": []})
-            evt_same.dispatch(var, user, target, actor_role)
-
-            user.send(*evt_same.data["actor_messages"])
-            target.send(*evt_same.data["target_messages"])
-
-        var.EXCHANGED_ROLES.append((actor, nick))
-        return True
-    return False
-
 @command("retract", "r", phases=("day", "join"))
 def retract(var, wrapper, message):
     """Takes back your vote during the day (for whom to lynch)."""
@@ -2899,15 +2804,6 @@ def retract(var, wrapper, message):
             break
     else:
         wrapper.pm(messages["pending_vote"])
-
-@event_listener("targeted_command", priority=9)
-def on_targeted_command(evt, var, actor, orig_target):
-    if evt.data["misdirection"]:
-        evt.data["target"] = users._get(choose_target(actor.nick, evt.data["target"].nick)) # FIXME
-
-    if evt.data["exchange"] and check_exchange(actor.client, actor.nick, evt.data["target"].nick):
-        evt.stop_processing = True
-        evt.prevent_default = True
 
 @hook("featurelist")  # For multiple targets with PRIVMSG
 def getfeatures(cli, nick, *rest):
@@ -3365,11 +3261,7 @@ def start(cli, nick, chan, forced = False, restart = ""):
     var.DAY_COUNT = 0
     var.TRAITOR_TURNED = False
     var.FINAL_ROLES = {}
-    var.LUCKY = set()
-    var.MISDIRECTED = set()
-    var.EXCHANGED = set()
     var.ABSTAINED = False
-    var.EXCHANGED_ROLES = []
     var.EXTRA_WOLVES = 0
 
     var.DEADCHAT_PLAYERS.clear()


### PR DESCRIPTION
This PR does several related things:
- Move misdirection and exchange under the `status` package;
- Remove the `targeted_command` event, replacing it by relevant calls to `try_misdirection` and `try_exchange`;
- Update the default imports in `_skel.py` and every role file - `from src.events import Event` => `from src.status import try_misdirection, try_exchange`;
- Get rid of the misdirection vs luck difference - it's now always called misdirection, and is applied to the actor or to the target;
- Remove the `exchange_roles` event, replacing every role that still uses it by `new_role` listeners and, where applicable, `swap_role_state` listeners;

Overall, this results in fewer lines of code while making the general quality better, as it becomes easier to follow through on what happens when a command is executed. Shamans still have different misdirection and luck totems, but this distinction is no longer reflected in the misdirection code.