### PR TITLE
Fix lynch stale state

### DIFF
--- a/src/votes.py
+++ b/src/votes.py
@@ -246,6 +246,9 @@ def chk_decision(var, *, timeout=False):
                         to_vote.extend(voting)
                 else:
                     abstaining = True
+            elif len(ABSTAINS | get_forced_abstains(var)) + len(VOTES) == avail:
+                # all people had voted and no conclusion can be made
+                abstaining = True
 
         if abstaining:
             for forced_abstainer in get_forced_abstains(var):


### PR DESCRIPTION
There was an issue that I encounter earlier when testing locally, where the engine would be stated during the lynching state.

It happens when the game only had three people left, where one of them abstain and the other two choose to lynch each other.

i.e. For person A, B, C:
```
A -> B
B -> A
C (no lynch)
```

Since the needed majority votes is ` needed = avail // 2 + 1` = `2`, none of the condition is met. Force lynch is not set on the server so there was neither any people have majority votes to be lynched nor the abstains votes being the majority.

I think in this scenario if force lynch is not set, it should be seen as abstaining for the day.