### PR TITLE
Add settings to disable moderating

### DIFF
--- a/src/settings.py
+++ b/src/settings.py
@@ -132,6 +132,12 @@ STATS_TYPE = "default" # default/accurate/team/disabled - what role information 
 START_VOTES_SCALE = 0.3
 START_VOTES_MAX = 4
 
+# Custom settings to disable auto bot moderating
+DISABLE_TIMERS = False
+DISABLE_TIME_LORD = False
+DISABLE_REAPER = False
+DISABLE_STASIS = False
+
 # Debug mode settings, whether or not timers and stasis should apply during debug mode
 DISABLE_DEBUG_MODE_TIMERS = True
 DISABLE_DEBUG_MODE_TIME_LORD = False

--- a/src/wolfgame.py
+++ b/src/wolfgame.py
@@ -126,7 +126,7 @@ var.DISCONNECTED = UserDict() # type: UserDict[User, Tuple[datetime, str]]
 
 var.RESTARTING = False
 
-if botconfig.DEBUG_MODE and var.DISABLE_DEBUG_MODE_TIMERS:
+if var.DISABLE_TIMERS or (botconfig.DEBUG_MODE and var.DISABLE_DEBUG_MODE_TIMERS):
     var.NIGHT_TIME_LIMIT = 0 # 120
     var.NIGHT_TIME_WARN = 0 # 90
     var.DAY_TIME_LIMIT = 0 # 720
@@ -134,20 +134,20 @@ if botconfig.DEBUG_MODE and var.DISABLE_DEBUG_MODE_TIMERS:
     var.SHORT_DAY_LIMIT = 0 # 520
     var.SHORT_DAY_WARN = 0 # 400
 
-if botconfig.DEBUG_MODE and var.DISABLE_DEBUG_MODE_REAPER:
+if var.DISABLE_REAPER or (botconfig.DEBUG_MODE and var.DISABLE_DEBUG_MODE_REAPER):
     var.KILL_IDLE_TIME = 0 # 300
     var.WARN_IDLE_TIME = 0 # 180
     var.PM_WARN_IDLE_TIME = 0 # 240
     var.JOIN_TIME_LIMIT = 0 # 3600
 
-if botconfig.DEBUG_MODE and var.DISABLE_DEBUG_MODE_STASIS:
+if var.DISABLE_STASIS or (botconfig.DEBUG_MODE and var.DISABLE_DEBUG_MODE_STASIS):
     var.LEAVE_PENALTY = 0
     var.IDLE_PENALTY = 0
     var.NIGHT_IDLE_PENALTY = 0
     var.PART_PENALTY = 0
     var.ACC_PENALTY = 0
 
-if botconfig.DEBUG_MODE and var.DISABLE_DEBUG_MODE_TIME_LORD:
+if var.DISABLE_TIME_LORD or (botconfig.DEBUG_MODE and var.DISABLE_DEBUG_MODE_TIME_LORD):
     var.TIME_LORD_DAY_LIMIT = 0 # 60
     var.TIME_LORD_DAY_WARN = 0 # 45
     var.TIME_LORD_NIGHT_LIMIT = 0 # 30


### PR DESCRIPTION
This is an excellent repo, and when I was hosting some friendly game with friends recently (with webcams) I found the auto bot moderating to be a bit annoying (as we all know each other and doesn't need the bot to do timers or idle moderating). I saw these settings exist for debug mode but not in normal mode.

These changes allow `botconfig.py` to customise the moderating behaviour of the bot.