### PR TITLE
RFC: modify guardian_lose_with_guards win condition in guardian

### DIFF
--- a/src/gamemodes/guardian.py
+++ b/src/gamemodes/guardian.py
@@ -49,7 +49,8 @@ class GuardianMode(GameMode):
 
     def chk_win(self, evt, var, rolemap, mainroles, lpl, lwolves, lrealwolves):
         lguardians = len(get_players(["guardian angel", "bodyguard"], mainroles=mainroles))
-
+        lpl_with_absent = len(get_players)
+        
         if lpl < 1:
             # handled by default win cond checking
             return
@@ -65,7 +66,7 @@ class GuardianMode(GameMode):
         elif not lrealwolves and not lguardians:
             evt.data["winner"] = "villagers"
             evt.data["message"] = messages["guardian_lose_no_guards"]
-        elif lwolves == lguardians and lpl - lwolves - lguardians == 0:
+        elif lwolves == lguardians and lpl_with_absent - lwolves - lguardians == 0:
             evt.data["winner"] = "wolves"
             evt.data["message"] = messages["guardian_lose_with_guards"]
         else:


### PR DESCRIPTION
Recent guardian game [~2010-12-20 23:00 UTC] had this rather surprising interaction:
The day started with 3 wolves alive, 2 GA, and 1 vil alive.
wolf gunner shoots and wounds one of GA, and gets lynched afterward.
On their lynch, guardian_lose_with_guards gets triggered.
Triggering wolf win condition on wolf lynch seems counterintuitive, so this patch seeks to alleviate that.

An alternate fix would be switching `lwolves == lguardians` to `lwolves >= lguardians` so wolves would get their win when GA was shot, not sure what was an intention here.
 