### PR TITLE
Update type annotations to the point where mypy is satisfied

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,6 +1,12 @@
 [mypy]
 python_version = 3.7
 
-# src.messages.* is mostly antlr4-generated and tends to spam the output. Ignore it entirely for now.
-[mypy-src.messages.*]
+# ignore generated files
+[mypy-src.messages.message_lexer]
+ignore_errors=True
+
+[mypy-src.messages.message_parser]
+ignore_errors=True
+
+[mypy-src.messages.message_parserListener]
 ignore_errors=True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,6 @@
+[mypy]
+python_version = 3.7
+
+# src.messages.* is mostly antlr4-generated and tends to spam the output. Ignore it entirely for now.
+[mypy-src.messages.*]
+ignore_errors=True

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,7 +2,7 @@ import argparse
 import datetime
 import time
 
-import botconfig
+import botconfig  # type: ignore
 
 # Enforce a strict import ordering to ensure things are properly defined when they need to be
 

--- a/src/cats.py
+++ b/src/cats.py
@@ -20,6 +20,8 @@
 # Village Objective: If all of the players with this cat are dead, the village wins.
 #    Only main roles are considered for this.
 
+from __future__ import annotations
+
 from collections import defaultdict
 from typing import Dict
 import itertools
@@ -32,10 +34,10 @@ __all__ = [
     "Spy", "Intuitive", "Cursed", "Innocent", "Team_Switcher", "Wolf_Objective", "Village_Objective", "All"
 ]
 
-_dict_keys = type(dict().keys())
+_dict_keys = type(dict().keys())  # type: ignore
 
 # Mapping of category names to the categories themselves; populated in Category.__init__
-ROLE_CATS = {} # type: Dict[str, Category]
+ROLE_CATS: Dict[str, Category] = {}
 
 # the ordering in which we list roles (values should be categories, and roles are ordered within the categories in alphabetical order,
 # with exception that wolf is first in the wolf category and villager is last in the village category)
@@ -44,7 +46,7 @@ ROLE_ORDER = ["Wolf", "Wolfchat", "Wolfteam", "Village", "Hidden", "Win Stealer"
 
 FROZEN = False
 
-ROLES = {}
+ROLES: Dict[str, str] = {}
 
 def get(cat):
     if not FROZEN:

--- a/src/cats.py
+++ b/src/cats.py
@@ -46,7 +46,7 @@ ROLE_ORDER = ["Wolf", "Wolfchat", "Wolfteam", "Village", "Hidden", "Win Stealer"
 
 FROZEN = False
 
-ROLES: Dict[str, str] = {}
+ROLES = {}
 
 def get(cat):
     if not FROZEN:

--- a/src/channels.py
+++ b/src/channels.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import time
 
 from enum import Enum

--- a/src/channels.py
+++ b/src/channels.py
@@ -1,6 +1,7 @@
 import time
 
 from enum import Enum
+from typing import Optional
 
 from src.context import IRCContext, Features, lower
 from src.events import Event, EventListener
@@ -8,9 +9,9 @@ from src import settings as var
 from src import users, stream
 from src.debug import CheckedSet, CheckedDict
 
-Main = None # main channel
-Dummy = None # fake channel
-Dev = None # dev channel
+Main: Optional[Channel] = None # main channel
+Dummy: Optional[Channel] = None # fake channel
+Dev: Optional[Channel] = None # dev channel
 
 _channels = CheckedDict("channels._channels") # type: CheckedDict[str, Channel]
 

--- a/src/channels.py
+++ b/src/channels.py
@@ -11,8 +11,8 @@ from src import settings as var
 from src import users, stream
 from src.debug import CheckedSet, CheckedDict
 
-Main: Optional[Channel] = None # main channel
-Dummy: Optional[Channel] = None # fake channel
+Main: Channel = None # type: ignore[assignment]
+Dummy: Channel = None # type: ignore[assignment]
 Dev: Optional[Channel] = None # dev channel
 
 _channels = CheckedDict("channels._channels") # type: CheckedDict[str, Channel]
@@ -349,5 +349,3 @@ class FakeChannel(Channel):
                     targets.append(target)
 
         self.update_modes(users.Bot, "".join(modes), targets)
-
-# vim: set sw=4 expandtab:

--- a/src/containers.py
+++ b/src/containers.py
@@ -1,8 +1,14 @@
+from __future__ import annotations
+
 import copy
+from typing import Dict, Generic, List, Set, TypeVar
 
 from src.users import User
 
 __all__ = ["UserList", "UserSet", "UserDict", "DefaultUserDict"]
+
+KT = TypeVar("KT")
+VT = TypeVar("VT")
 
 """ * Important *
 
@@ -60,9 +66,10 @@ class Container:
     def __deepcopy__(self, memo):
         return type(self)(copy.deepcopy(x, memo) for x in self)
 
-    copy = __copy__
+    def copy(self):
+        return self.__copy__()
 
-class UserList(Container, list):
+class UserList(Container, List[User]):
     def __init__(self, iterable=()):
         super().__init__()
         try:
@@ -149,7 +156,7 @@ class UserList(Container, list):
         if item not in self:
             item.lists.remove(self)
 
-class UserSet(Container, set):
+class UserSet(Container, Set[User]):
     def __init__(self, iterable=()):
         super().__init__()
         try:
@@ -164,28 +171,28 @@ class UserSet(Container, set):
 
     # Augmented assignment method overrides
 
-    def __iand__(self, other):
+    def __iand__(self, other):  # type: ignore
         if not isinstance(other, set):
             return NotImplemented
 
         self.intersection_update(other)
         return self
 
-    def __ior__(self, other):
+    def __ior__(self, other):  # type: ignore
         if not isinstance(other, set):
             return NotImplemented
 
         self.update(other)
         return self
 
-    def __isub__(self, other):
+    def __isub__(self, other):  # type: ignore
         if not isinstance(other, set):
             return NotImplemented
 
         self.difference_update(other)
         return
 
-    def __ixor__(self, other):
+    def __ixor__(self, other):  # type: ignore
         if not isinstance(other, set):
             return NotImplemented
 
@@ -256,7 +263,7 @@ class UserSet(Container, set):
             if item not in self:
                 self.add(item)
 
-class UserDict(Container, dict):
+class UserDict(Container, Dict[KT, VT], Generic[KT, VT]):
     def __init__(_self, _it=(), **kwargs):
         super().__init__()
         if hasattr(_it, "items"):
@@ -376,7 +383,7 @@ class UserDict(Container, dict):
         for key, value in iterable:
             self[key] = value
 
-class DefaultUserDict(UserDict):
+class DefaultUserDict(UserDict[KT, VT], Generic[KT, VT]):
     def __init__(_self, _factory, _it=(), **kwargs):
         _self.factory = _factory
         super().__init__(_it, **kwargs)

--- a/src/context.py
+++ b/src/context.py
@@ -122,9 +122,7 @@ def context_types(*types):
 class IRCContext:
     """Base class for channels and users."""
 
-    _messages: Dict[str, List[IRCContext]] = defaultdict(list)
-
-    is_fake: ClassVar[bool] = False
+    _messages = defaultdict(list)
 
     def __init__(self, name, client):
         self.name = name
@@ -321,8 +319,7 @@ class IRCFeatures:
         modes = self._features.get("CHANMODES", [])
         while len(modes) < 4:
             modes.append("")
-        rA, rB, rC, rD = modes[:4]
-        return (rA, rB, rC, rD)
+        return tuple(modes[:4])
 
     @CHANMODES.setter
     def CHANMODES(self, value: str):

--- a/src/db/__init__.py
+++ b/src/db/__init__.py
@@ -8,7 +8,7 @@ from collections import defaultdict
 import threading
 from datetime import datetime
 
-import botconfig
+import botconfig  # type: ignore
 import src.settings as var
 from src.utilities import singular
 from src.messages import messages, LocalRole

--- a/src/debug/dict.py
+++ b/src/debug/dict.py
@@ -1,6 +1,6 @@
-from typing import Iterator, TypeVar, Union, Set, Dict, Mapping, Iterable
+from typing import Generic, Iterator, TypeVar, Union, Set, Dict, Mapping, Iterable
 import collections.abc
-import botconfig
+import botconfig  # type: ignore
 from src.debug.history import History
 
 __all__ = ["CheckedDict"]
@@ -10,7 +10,7 @@ VT = TypeVar("VT")
 KT_co = TypeVar("KT_co", covariant=True)
 VT_co = TypeVar("VT_co", covariant=True)
 
-class CheckedDict(collections.abc.MutableMapping):
+class CheckedDict(collections.abc.MutableMapping, Generic[KT, VT]):
     """ Dict container with additional features to aid in debugging.
 
     Common mutation methods are exposed to more easily set breakpoints,
@@ -30,9 +30,9 @@ class CheckedDict(collections.abc.MutableMapping):
     def __init__(self, name: str, arg: Union[None, Mapping, Iterable] = None, **kwargs):
         self._history = History(name)
         if arg is None:
-            self._dict = dict(**kwargs) # type: Dict[KT, VT]
+            self._dict: Dict[KT, VT] = dict(**kwargs)
         else:
-            self._dict = dict(arg, **kwargs) # type: Dict[KT, VT]
+            self._dict = dict(arg, **kwargs)
 
     def clear(self) -> None:
         self._history.add("clear")
@@ -46,7 +46,7 @@ class CheckedDict(collections.abc.MutableMapping):
         self._history.add("delitem", k)
         del self._dict[k]
 
-    def __getitem__(self, k: KT) -> VT_co:
+    def __getitem__(self, k: KT) -> VT:
         return self._dict[k]
 
     def __len__(self) -> int:
@@ -61,5 +61,5 @@ class CheckedDict(collections.abc.MutableMapping):
     def __repr__(self) -> str:
         return repr(self._dict)
 
-    def __iter__(self) -> Iterator[KT_co]:
+    def __iter__(self) -> Iterator[KT]:
         return iter(self._dict)

--- a/src/debug/dict.py
+++ b/src/debug/dict.py
@@ -7,8 +7,6 @@ __all__ = ["CheckedDict"]
 
 KT = TypeVar("KT")
 VT = TypeVar("VT")
-KT_co = TypeVar("KT_co", covariant=True)
-VT_co = TypeVar("VT_co", covariant=True)
 
 class CheckedDict(collections.abc.MutableMapping, Generic[KT, VT]):
     """ Dict container with additional features to aid in debugging.

--- a/src/debug/history.py
+++ b/src/debug/history.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import traceback
 from typing import Set, List, Tuple, Dict, Optional
-import botconfig
+import botconfig  # type: ignore
 
 __all__ = ["History", "enable_history", "disable_history"]
 

--- a/src/debug/set.py
+++ b/src/debug/set.py
@@ -1,6 +1,8 @@
-from typing import Iterator, TypeVar, Optional, Set
+from __future__ import annotations
+
+from typing import Generic, Iterator, TypeVar, Optional, Set
 import collections.abc
-import botconfig
+import botconfig  # type: ignore
 from src.debug.history import History
 
 __all__ = ["CheckedSet"]
@@ -8,7 +10,7 @@ __all__ = ["CheckedSet"]
 T = TypeVar("T")
 T_co = TypeVar("T_co", covariant=True)
 
-class CheckedSet(collections.abc.MutableSet):
+class CheckedSet(collections.abc.MutableSet, Generic[T_co]):
     """ Set container with additional features to aid in debugging.
 
     Common mutation methods are exposed to more easily set breakpoints,
@@ -16,7 +18,7 @@ class CheckedSet(collections.abc.MutableSet):
     collection was modified in the past.
     """
 
-    def __new__(cls, name: str, iterable: Optional[Iterator[T_co]] = None):
+    def __new__(cls, name: str, iterable: Optional[Iterator[T]] = None):
         if not botconfig.DEBUG_MODE:
             if iterable is None:
                 return set()
@@ -25,14 +27,14 @@ class CheckedSet(collections.abc.MutableSet):
 
         return super().__new__(cls)
 
-    def __init__(self, name: str, iterable: Optional[Iterator[T_co]] = None):
+    def __init__(self, name: str, iterable: Optional[Iterator[T]] = None):
         self._history = History(name)
         if iterable is None:
-            self._set = set() # type: Set[T]
+            self._set: Set[T] = set()
         else:
-            self._set = set(iterable) # type: Set[T]
+            self._set = set(iterable)
 
-    def __iter__(self) -> Iterator[T_co]:
+    def __iter__(self) -> Iterator[T]:
         return iter(self._set)
 
     def __len__(self) -> int:

--- a/src/events.py
+++ b/src/events.py
@@ -1,8 +1,10 @@
 # event system
+from __future__ import annotations
+
 from collections import defaultdict
 from types import SimpleNamespace
-from typing import Callable, Optional
-EVENT_CALLBACKS = defaultdict(list)
+from typing import Callable, Dict, List, Optional
+EVENT_CALLBACKS: Dict[str, List[EventListener]] = defaultdict(list)
 
 __all__ = ["find_listener", "Event", "EventListener"]
 

--- a/src/functions.py
+++ b/src/functions.py
@@ -1,4 +1,6 @@
-from typing import Optional, Iterable
+from __future__ import annotations
+
+from typing import Optional, Set, Iterable
 from collections import Counter
 import functools
 
@@ -184,7 +186,7 @@ def match_role(var, role: str, remove_spaces: bool = False, allow_extra: bool = 
 
     role_map = messages.get_role_mapping(reverse=True, remove_spaces=remove_spaces)
 
-    special_keys = set()
+    special_keys: Set[str] = set()
     if scope is None and allow_special:
         evt = Event("get_role_metadata", {})
         evt.dispatch(var, "special_keys")
@@ -193,7 +195,7 @@ def match_role(var, role: str, remove_spaces: bool = False, allow_extra: bool = 
     matches = match_all(role, role_map.keys())
 
     # strip matches that don't refer to actual roles or special keys (i.e. refer to team names)
-    filtered_matches = set()
+    filtered_matches: Set[LocalRole] = set()
     if scope is not None:
         allowed = set(scope)
     elif allow_extra:

--- a/src/gamemodes/maelstrom.py
+++ b/src/gamemodes/maelstrom.py
@@ -2,7 +2,7 @@ import random
 import copy
 from datetime import datetime
 from collections import defaultdict, Counter
-import botconfig
+import botconfig  # type: ignore
 from src.gamemodes import game_mode, GameMode, InvalidModeException
 from src.messages import messages
 from src.functions import get_players

--- a/src/handler.py
+++ b/src/handler.py
@@ -1,5 +1,7 @@
 # The bot commands implemented in here are present no matter which module is loaded
 
+from __future__ import annotations
+
 import base64
 import socket
 import sys
@@ -9,9 +11,9 @@ import traceback
 import functools
 import statistics
 import math
-from typing import Optional
+from typing import List, Optional, Union
 
-import botconfig
+import botconfig  # type: ignore
 import src.settings as var
 from src import decorators, wolfgame, channels, users, plog
 from src.messages import messages
@@ -97,7 +99,7 @@ def parse_and_dispatch(var,
     parts = key.split(sep=":", maxsplit=1)
     if len(parts) > 1 and len(parts[0]) and not parts[0].isnumeric():
         key = parts[1]
-        role_prefix = parts[0]
+        role_prefix: Optional[str] = parts[0]
     else:
         key = parts[0]
         role_prefix = None
@@ -127,7 +129,7 @@ def parse_and_dispatch(var,
 
     # Don't change this into decorators.COMMANDS[key] even though it's a defaultdict,
     # as we don't want to insert bogus command keys into the dict.
-    cmds = []
+    cmds: List[command] = []
     phase = var.PHASE
     if context.source in get_participants():
         roles = get_all_roles(context.source)
@@ -168,7 +170,7 @@ def parse_and_dispatch(var,
         # is executed. In this event, display a helpful error message instructing
         # the user to resolve the ambiguity.
         common_roles = set(roles)
-        info = [0, 0]
+        info: List[Union[str, int]] = [0, 0]
         role_map = messages.get_role_mapping()
         for fn in cmds:
             fn_roles = roles.intersection(fn.roles)
@@ -192,8 +194,10 @@ def parse_and_dispatch(var,
                 wrapper.pm(messages["no_force_admin"])
                 return
             if fn.chan:
+                assert channels.Main is not None
                 context.target = channels.Main
             else:
+                assert users.Bot is not None
                 context.target = users.Bot
         if phase == var.PHASE:  # don't call any more commands if one we just called executed a phase transition
             fn.caller(var, context, message)

--- a/src/handler.py
+++ b/src/handler.py
@@ -194,10 +194,8 @@ def parse_and_dispatch(var,
                 wrapper.pm(messages["no_force_admin"])
                 return
             if fn.chan:
-                assert channels.Main is not None
                 context.target = channels.Main
             else:
-                assert users.Bot is not None
                 context.target = users.Bot
         if phase == var.PHASE:  # don't call any more commands if one we just called executed a phase transition
             fn.caller(var, context, message)

--- a/src/lineparse.py
+++ b/src/lineparse.py
@@ -61,8 +61,7 @@ class LineParser(ArgumentParser):
         self.allow_intermixed = False
         return super().add_subparsers(**kwargs)
 
-    def parse_args(self, args: Optional[Sequence[str]] = None, namespace: Optional[Namespace] = None) -> Namespace:  # type: ignore
-        # parse_args has a difficult type signature to follow
+    def parse_args(self, args: Optional[Sequence[str]] = None, namespace: Optional[Namespace] = None) -> Namespace:
         if args is None:
             # args=None is supported by ArgumentParser to read args from sys.argv but we don't want to do that here
             raise TypeError("LineParser requires an args list to be passed in")

--- a/src/lineparse.py
+++ b/src/lineparse.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from argparse import ArgumentParser, Namespace, Action
 from typing import Optional, Sequence, IO, NoReturn
 
@@ -59,7 +61,8 @@ class LineParser(ArgumentParser):
         self.allow_intermixed = False
         return super().add_subparsers(**kwargs)
 
-    def parse_args(self, args: Optional[Sequence[str]] = None, namespace: Optional[Namespace] = None) -> Namespace:
+    def parse_args(self, args: Optional[Sequence[str]] = None, namespace: Optional[Namespace] = None) -> Namespace:  # type: ignore
+        # parse_args has a difficult type signature to follow
         if args is None:
             # args=None is supported by ArgumentParser to read args from sys.argv but we don't want to do that here
             raise TypeError("LineParser requires an args list to be passed in")
@@ -69,9 +72,9 @@ class LineParser(ArgumentParser):
             parse = self.parse_known_intermixed_args
         else:
             parse = self.parse_known_args
-        args, argv = parse(args, namespace)
+        out_args, argv = parse(args, namespace)
         # allow the help option to work even if all required positionals aren't there
         if argv:
             self.error("unrecognized arguments: {}".format(" ".join(argv)))
 
-        return args
+        return out_args

--- a/src/logger.py
+++ b/src/logger.py
@@ -1,7 +1,7 @@
 import datetime
 import time
 
-import botconfig
+import botconfig  # type: ignore
 
 def logger(file, write=True, display=True):
     if file is not None:

--- a/src/match.py
+++ b/src/match.py
@@ -1,10 +1,10 @@
-from typing import Generic, Iterable, TypeVar, Optional
+from typing import Generic, Iterable, Iterator, TypeVar, Optional
 
 __all__ = ["Match", "match_all", "match_one"]
 
 T = TypeVar("T")
 
-class Match(Generic[T]):
+class Match(Iterable[T], Generic[T]):
     def __init__(self, matches: Iterable[T]):
         self._matches = list(matches)
 
@@ -14,7 +14,7 @@ class Match(Generic[T]):
     def __len__(self) -> int:
         return len(self._matches)
 
-    def __iter__(self) -> Iterable[T]:
+    def __iter__(self) -> Iterator[T]:
         return iter(self._matches)
 
     def get(self) -> T:

--- a/src/messages/formatter.py
+++ b/src/messages/formatter.py
@@ -103,7 +103,7 @@ class Formatter(string.Formatter):
             value = self._article(value, specs["article"])
             del specs["article"]
         if "!" in specs:
-            from botconfig import CMD_CHAR
+            from botconfig import CMD_CHAR  # type: ignore
             value = "{}{}".format(CMD_CHAR, value)
             del specs["!"]
 

--- a/src/messages/formatter.py
+++ b/src/messages/formatter.py
@@ -103,7 +103,7 @@ class Formatter(string.Formatter):
             value = self._article(value, specs["article"])
             del specs["article"]
         if "!" in specs:
-            from botconfig import CMD_CHAR  # type: ignore
+            from botconfig import CMD_CHAR
             value = "{}{}".format(CMD_CHAR, value)
             del specs["!"]
 

--- a/src/messages/parser.py
+++ b/src/messages/parser.py
@@ -1,6 +1,6 @@
 import sys
 from typing import TextIO
-from antlr4 import TokenStream
+from antlr4 import TokenStream  # type: ignore
 from src.messages.message_parser import message_parser
 
 class Parser(message_parser):

--- a/src/pregame.py
+++ b/src/pregame.py
@@ -29,7 +29,7 @@ WAIT_LOCK = threading.RLock()
 WAIT_TOKENS = 0
 WAIT_LAST = 0
 
-LAST_START: UserDict[User, List[Union[datetime, int]]] = UserDict()  # FIXME: this should probably be a class containing two fields
+LAST_START: UserDict[User, List[Union[datetime, int]]] = UserDict()
 LAST_WAIT: UserDict[User, datetime] = UserDict()
 START_VOTES: UserSet = UserSet()
 RESTART_TRIES: int = 0

--- a/src/pregame.py
+++ b/src/pregame.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections import defaultdict, Counter
 from datetime import datetime, timedelta
 
@@ -7,6 +9,7 @@ import random
 import time
 import math
 import re
+from typing import TYPE_CHECKING, List, Union
 
 from src.containers import UserDict, UserSet
 from src.decorators import COMMANDS, command, event_listener, handle_error
@@ -17,16 +20,19 @@ from src.events import Event
 from src.cats import Wolfchat, All
 from src import channels
 
-import botconfig
+if TYPE_CHECKING:
+    from src.users import User
+
+import botconfig  # type: ignore
 
 WAIT_LOCK = threading.RLock()
 WAIT_TOKENS = 0
 WAIT_LAST = 0
 
-LAST_START = UserDict() # type: UserDict[users.User, List[datetime, int]]
-LAST_WAIT = UserDict() # type: UserDict[users.User, datetime]
-START_VOTES = UserSet() # type: UserSet[users.User]
-RESTART_TRIES = 0 # type: int
+LAST_START: UserDict[User, List[Union[datetime, int]]] = UserDict()  # FIXME: this should probably be a class containing two fields
+LAST_WAIT: UserDict[User, datetime] = UserDict()
+START_VOTES: UserSet = UserSet()
+RESTART_TRIES: int = 0
 MAX_RETRIES = 3 # constant: not a setting
 
 @command("wait", playing=True, phases=("join",))

--- a/src/roles/alphawolf.py
+++ b/src/roles/alphawolf.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 import re
 import random
+from typing import TYPE_CHECKING
 
 from src.utilities import *
 from src import users, channels, debuglog, errlog, plog
@@ -11,11 +14,14 @@ from src.status import try_misdirection, try_exchange, add_lycanthropy, add_lyca
 from src.cats import Wolf, All
 from src.roles.helper.wolves import is_known_wolf_ally, send_wolfchat_message, register_wolf
 
+if TYPE_CHECKING:
+    from src.users import User
+
 register_wolf("alpha wolf")
 
 ENABLED = False
-ALPHAS = UserSet() # type: UserSet[users.User]
-BITTEN = UserDict() # type: UserDict[users.User, users.User]
+ALPHAS = UserSet()
+BITTEN: UserDict[User, User] = UserDict()
 
 @command("bite", chan=False, pm=True, playing=True, silenced=True, phases=("night",), roles=("alpha wolf",))
 def observe(var, wrapper, message):

--- a/src/roles/bodyguard.py
+++ b/src/roles/bodyguard.py
@@ -1,22 +1,26 @@
+from __future__ import annotations
+
 import re
 import random
 import itertools
 import math
 from collections import defaultdict
+from typing import Set
 
 import src.settings as var
 from src.utilities import *
-from src import users, channels, debuglog, errlog, plog
+from src import channels, debuglog, errlog, plog
 from src.functions import get_players, get_all_players, get_target, get_main_role
 from src.decorators import command, event_listener
 from src.containers import UserList, UserSet, UserDict, DefaultUserDict
 from src.messages import messages
 from src.status import try_misdirection, try_exchange, add_protection, add_dying
 from src.cats import Wolf
+from src.users import User
 
-GUARDED = UserDict() # type: UserDict[users.User, users.User]
+GUARDED: UserDict[User, User] = UserDict()
 PASSED = UserSet()
-DYING = set()
+DYING: Set[User] = set()
 
 @command("guard", chan=False, pm=True, playing=True, silenced=True, phases=("night",), roles=("bodyguard",))
 def guard(var, wrapper, message):

--- a/src/roles/bodyguard.py
+++ b/src/roles/bodyguard.py
@@ -20,7 +20,7 @@ from src.users import User
 
 GUARDED: UserDict[User, User] = UserDict()
 PASSED = UserSet()
-DYING: Set[User] = set()
+DYING = UserSet()
 
 @command("guard", chan=False, pm=True, playing=True, silenced=True, phases=("night",), roles=("bodyguard",))
 def guard(var, wrapper, message):
@@ -147,6 +147,7 @@ def on_begin_day(evt, var):
 def on_reset(evt, var):
     GUARDED.clear()
     PASSED.clear()
+    DYING.clear()
 
 @event_listener("get_role_metadata")
 def on_get_role_metadata(evt, var, kind):

--- a/src/roles/doomsayer.py
+++ b/src/roles/doomsayer.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 import re
 import random
+from typing import TYPE_CHECKING
 
 from src import users, channels, status, debuglog, errlog, plog
 from src.functions import get_players, get_all_players, get_main_role, get_target
@@ -11,13 +14,16 @@ from src.cats import All
 
 from src.roles.helper.wolves import is_known_wolf_ally, register_wolf, send_wolfchat_message
 
+if TYPE_CHECKING:
+    from src.users import User
+
 register_wolf("doomsayer")
 
 SEEN = UserSet()
-LASTSEEN = UserDict() # type: UserDict[users.User, users.User]
-KILLS = UserDict()
-SICK = UserDict()
-LYCANS = UserDict()
+LASTSEEN: UserDict[User, User] = UserDict()
+KILLS: UserDict[User, User] = UserDict()
+SICK: UserDict[User, User] = UserDict()
+LYCANS: UserDict[User, User] = UserDict()
 
 _mappings = ("death", KILLS), ("lycan", LYCANS), ("sick", SICK)
 

--- a/src/roles/helper/shamans.py
+++ b/src/roles/helper/shamans.py
@@ -310,7 +310,7 @@ def give_totem(var, wrapper, target, totem, *, key, role) -> Optional[Tuple[user
 
     target = try_misdirection(var, wrapper.source, target)
     if try_exchange(var, wrapper.source, target):
-        return
+        return None
 
     targrole = get_main_role(target)
 

--- a/src/roles/jester.py
+++ b/src/roles/jester.py
@@ -12,7 +12,7 @@ from src.containers import UserList, UserSet, UserDict, DefaultUserDict
 from src.messages import messages
 from src.status import try_misdirection, try_exchange
 
-JESTERS = UserSet() # type: UserSet[users.User]
+JESTERS = UserSet()
 
 @event_listener("lynch")
 def on_lynch(evt, var, votee, voters):

--- a/src/roles/matchmaker.py
+++ b/src/roles/matchmaker.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 
 MATCHMAKERS = UserSet()
 ACTED = UserSet()
-LOVERS: UserDict[User, User] = UserDict()
+LOVERS = UserDict()
 
 def _set_lovers(target1, target2):
     if target1 in LOVERS:

--- a/src/roles/matchmaker.py
+++ b/src/roles/matchmaker.py
@@ -1,8 +1,11 @@
+from __future__ import annotations
+
 import re
 import random
 import itertools
 import math
 from collections import defaultdict
+from typing import TYPE_CHECKING
 
 from src.utilities import *
 from src import channels, users, debuglog, errlog, plog
@@ -13,9 +16,12 @@ from src.messages import messages
 from src.status import try_misdirection, try_exchange, add_dying
 from src.cats import Win_Stealer
 
+if TYPE_CHECKING:
+    from src.users import User
+
 MATCHMAKERS = UserSet()
 ACTED = UserSet()
-LOVERS = UserDict()
+LOVERS: UserDict[User, User] = UserDict()
 
 def _set_lovers(target1, target2):
     if target1 in LOVERS:

--- a/src/roles/minion.py
+++ b/src/roles/minion.py
@@ -4,7 +4,7 @@ import itertools
 import math
 from collections import defaultdict
 
-import botconfig
+import botconfig  # type: ignore
 from src.utilities import *
 from src import channels, users, debuglog, errlog, plog
 from src.functions import get_players, get_all_players, get_main_role, get_reveal_role, get_target

--- a/src/roles/priest.py
+++ b/src/roles/priest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 import random
 import itertools
@@ -13,7 +15,7 @@ from src.messages import messages
 from src.events import Event
 from src.status import try_misdirection, try_exchange, add_absent
 
-PRIESTS = UserSet() # type: Set[users.User]
+PRIESTS = UserSet()
 
 @command("bless", chan=False, pm=True, playing=True, silenced=True, phases=("day",), roles=("priest",))
 def bless(var, wrapper, message):

--- a/src/roles/sorcerer.py
+++ b/src/roles/sorcerer.py
@@ -16,7 +16,7 @@ from src.roles.helper.wolves import is_known_wolf_ally, send_wolfchat_message, r
 
 register_wolf("sorcerer")
 
-OBSERVED = UserSet() # type: UserSet[users.User]
+OBSERVED = UserSet()
 
 @command("observe", chan=False, pm=True, playing=True, silenced=True, phases=("night",), roles=("sorcerer",))
 def observe(var, wrapper, message):

--- a/src/roles/warlock.py
+++ b/src/roles/warlock.py
@@ -1,8 +1,11 @@
+from __future__ import annotations
+
 import re
 import random
 import itertools
 import math
 from collections import defaultdict
+from typing import TYPE_CHECKING
 
 from src.utilities import *
 from src import channels, users, debuglog, errlog, plog
@@ -13,10 +16,13 @@ from src.messages import messages
 from src.status import try_misdirection, try_exchange
 from src.roles.helper.wolves import get_wolfchat_roles, is_known_wolf_ally, send_wolfchat_message, get_wolflist, register_wolf
 
+if TYPE_CHECKING:
+    from src.users import User
+
 register_wolf("warlock")
 
-CURSED = UserDict() # type: UserDict[users.User, users.User]
-PASSED = UserSet() # type: UserSet[users.Set]
+CURSED: UserDict[User, User] = UserDict()
+PASSED: UserSet = UserSet()
 
 @command("curse", chan=False, pm=True, playing=True, silenced=True, phases=("night",), roles=("warlock",))
 def curse(var, wrapper, message):

--- a/src/roles/wildchild.py
+++ b/src/roles/wildchild.py
@@ -1,8 +1,11 @@
+from __future__ import annotations
+
 import re
 import random
 import itertools
 import math
 from collections import defaultdict
+from typing import TYPE_CHECKING
 
 from src.utilities import *
 from src import channels, users, debuglog, errlog, plog
@@ -14,7 +17,10 @@ from src.status import try_misdirection, try_exchange
 
 from src.roles.helper.wolves import get_wolfchat_roles
 
-IDOLS = UserDict()
+if TYPE_CHECKING:
+    from src.users import User
+
+IDOLS: UserDict[User, User] = UserDict()
 CAN_ACT = UserSet()
 ACTED = UserSet()
 

--- a/src/settings.py
+++ b/src/settings.py
@@ -173,7 +173,7 @@ AMNESIAC_NIGHTS = 3 # amnesiac gets to know their actual role on this night
 
 DOCTOR_IMMUNIZATION_MULTIPLIER = 0.135 # ceil(num_players * multiplier) = number of immunizations
 
-GAME_MODES: Dict[str, Any] = {}
+GAME_MODES = {}
 GAME_PHASES = ("night", "day") # all phases that constitute "in game", game modes can extend this with custom phases
 
 # IP address to bind to before connecting, or empty string to use OS default

--- a/src/settings.py
+++ b/src/settings.py
@@ -1,7 +1,10 @@
+from __future__ import annotations
+
 import fnmatch
 import re
 import threading
 from collections import OrderedDict
+from typing import Any, Dict, FrozenSet
 
 LANGUAGE = 'en'
 
@@ -170,7 +173,7 @@ AMNESIAC_NIGHTS = 3 # amnesiac gets to know their actual role on this night
 
 DOCTOR_IMMUNIZATION_MULTIPLIER = 0.135 # ceil(num_players * multiplier) = number of immunizations
 
-GAME_MODES = {}
+GAME_MODES: Dict[str, Any] = {}
 GAME_PHASES = ("night", "day") # all phases that constitute "in game", game modes can extend this with custom phases
 
 # IP address to bind to before connecting, or empty string to use OS default
@@ -225,13 +228,13 @@ DEFAULT_ROLE = "villager"
 HIDDEN_ROLE = "villager"
 
 # Roles listed here cannot be used in !fgame roles=blah.
-DISABLED_ROLES = frozenset()
+DISABLED_ROLES: FrozenSet[str] = frozenset()
 
 # Game modes that cannot be randomly picked or voted for
-DISABLED_GAMEMODES = frozenset()
+DISABLED_GAMEMODES: FrozenSet[str] = frozenset()
 
 # Commands listed here cannot be used by anyone (even admins/owners)
-DISABLED_COMMANDS = frozenset()
+DISABLED_COMMANDS: FrozenSet[str] = frozenset()
 
 GIF_CHANCE = 1/50
 

--- a/src/status/absent.py
+++ b/src/status/absent.py
@@ -1,11 +1,18 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from src.decorators import event_listener
 from src.containers import UserDict
 from src.functions import get_players
 from src.messages import messages
 
+if TYPE_CHECKING:
+    from src.users import User
+
 __all__ = ["add_absent", "try_absent", "get_absent"]
 
-ABSENT = UserDict() # type: UserDict[users.User, str]
+ABSENT: UserDict[User, str] = UserDict()
 
 def add_absent(var, target, reason):
     if target not in get_players():

--- a/src/status/dying.py
+++ b/src/status/dying.py
@@ -67,7 +67,7 @@ def kill_players(var, *, end_game: bool = True) -> bool:
     with var.GRAVEYARD_LOCK: # FIXME
         if not var.GAME_ID or var.GAME_ID > t:
             #  either game ended, or a new game has started
-            return True  # CHECK BEFORE PULLING: This used to say just "return" which appears to have been an actual bug. --GM
+            return True
 
         dead = set()
 
@@ -83,7 +83,7 @@ def kill_players(var, *, end_game: bool = True) -> bool:
             dead.add(player)
             # Don't track players that quit before the game started
             if var.PHASE != "join":
-	            var.DEAD.add(player)
+                var.DEAD.add(player)
             # notify listeners that the player died for possibility of chained deaths
             evt = Event("del_player", {},
                         killer_role=killer_role,

--- a/src/status/dying.py
+++ b/src/status/dying.py
@@ -67,7 +67,7 @@ def kill_players(var, *, end_game: bool = True) -> bool:
     with var.GRAVEYARD_LOCK: # FIXME
         if not var.GAME_ID or var.GAME_ID > t:
             #  either game ended, or a new game has started
-            return
+            return True  # CHECK BEFORE PULLING: This used to say just "return" which appears to have been an actual bug. --GM
 
         dead = set()
 

--- a/src/status/forcevote.py
+++ b/src/status/forcevote.py
@@ -22,27 +22,27 @@ __all__ = ["add_force_vote", "add_force_abstain", "can_vote", "can_abstain", "ge
 FORCED_COUNTS: UserDict[User, int] = UserDict()
 FORCED_TARGETS: UserDict[User, UserSet] = UserDict()
 
-def _add_count(var, votee : User, amount : int) -> None:
+def _add_count(var, votee: User, amount: int) -> None:
     FORCED_COUNTS[votee] = FORCED_COUNTS.get(votee, 0) + amount
     if FORCED_COUNTS[votee] == 0:
         # don't clear out FORCED_TARGETS, in case a future call re-forces votes
         # we want to maintain the full set of people to vote for
         del FORCED_COUNTS[votee]
 
-def add_force_vote(var, votee : User, targets : Iterable[User]) -> None:
+def add_force_vote(var, votee: User, targets: Iterable[User]) -> None:
     """Force votee to vote for the specified targets."""
     if votee not in get_players():
         return
     _add_count(var, votee, 1)
     FORCED_TARGETS.setdefault(votee, UserSet()).update(targets)
 
-def add_force_abstain(var, votee : User) -> None:
+def add_force_abstain(var, votee: User) -> None:
     """Force votee to abstain."""
     if votee not in get_players():
         return
     _add_count(var, votee, -1)
 
-def can_vote(var, votee : User, target : User) -> bool:
+def can_vote(var, votee: User, target: User) -> bool:
     """Check whether the votee can vote the target."""
     c = FORCED_COUNTS.get(votee, 0)
     if c < 0:
@@ -51,11 +51,11 @@ def can_vote(var, votee : User, target : User) -> bool:
         return True
     return target in FORCED_TARGETS[votee]
 
-def can_abstain(var, votee : User) -> bool:
+def can_abstain(var, votee: User) -> bool:
     """Check whether the votee can abstain."""
     return FORCED_COUNTS.get(votee, 0) <= 0
 
-def get_forced_votes(var, target : User) -> Set[User]:
+def get_forced_votes(var, target: User) -> Set[User]:
     """Retrieve the players who are being forced to vote target."""
     return {votee for votee, targets in FORCED_TARGETS.items() if target in targets}
 

--- a/src/status/lycanthropy.py
+++ b/src/status/lycanthropy.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from src.decorators import event_listener
 from src.containers import UserDict
 from src.functions import get_players, get_all_players, get_main_role, change_role
@@ -6,9 +10,13 @@ from src.events import Event
 from src.cats import Wolf
 from src import debuglog
 
+if TYPE_CHECKING:
+    from src.users import User
+
+
 __all__ = ["add_lycanthropy", "remove_lycanthropy", "add_lycanthropy_scope"]
 
-LYCANTHROPES = UserDict()
+LYCANTHROPES: UserDict[User, str] = UserDict()
 SCOPE = set()
 
 def add_lycanthropy(var, target, prefix="lycan"):

--- a/src/status/lynchimmune.py
+++ b/src/status/lynchimmune.py
@@ -1,12 +1,19 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Set
+
 from src.containers import DefaultUserDict
 from src.decorators import event_listener
 from src.functions import get_players
 from src.messages import messages
 from src.events import Event
 
+if TYPE_CHECKING:
+    from src.users import User
+
 __all__ = ["add_lynch_immunity", "try_lynch_immunity"]
 
-IMMUNITY = DefaultUserDict(set) # type: UserDict[User, set]
+IMMUNITY: DefaultUserDict[User, Set[str]] = DefaultUserDict(set)
 
 def add_lynch_immunity(var, user, reason):
     """Make user immune to lynching for one day."""

--- a/src/status/protection.py
+++ b/src/status/protection.py
@@ -1,13 +1,20 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, List, Optional, Tuple
+
 from src.containers import UserDict, DefaultUserDict
 from src.decorators import event_listener
 from src.functions import get_players
 from src.messages import messages
 from src.events import Event
-from src.cats import All
+from src.cats import All, Category
+
+if TYPE_CHECKING:
+    from src.users import User
 
 __all__ = ["add_protection", "try_protection", "remove_all_protections"]
 
-PROTECTIONS = UserDict() # type: UserDict[User, UserDict[Optional[User], List[Tuple[Category, str]]]]
+PROTECTIONS: UserDict[User, UserDict[Optional[User], List[Tuple[Category, str]]]] = UserDict()
 
 def add_protection(var, target, protector, protector_role, scope=All):
     """Add a protection to the target affecting the relevant scope."""

--- a/src/status/silence.py
+++ b/src/status/silence.py
@@ -1,10 +1,14 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from src.containers import UserSet
 from src.decorators import event_listener
 from src.messages import messages
 
 __all__ = ["add_silent", "is_silent"]
 
-SILENT = UserSet() # type: UserSet[users.User]
+SILENT: UserSet = UserSet()
 
 def add_silent(var, user):
     """Silence the target, preventing them from using actions for a day."""

--- a/src/users.py
+++ b/src/users.py
@@ -17,7 +17,7 @@ import botconfig  # type: ignore
 __all__ = ["Bot", "predicate", "get", "add", "users", "disconnected", "complete_match",
            "parse_rawnick", "parse_rawnick_as_dict", "User", "FakeUser", "BotUser"]
 
-Bot: Optional[BotUser] = None # bot instance
+Bot: BotUser = None # type: ignore[assignment]
 
 _users: CheckedSet[User] = CheckedSet("users._users")
 _ghosts: CheckedSet[User] = CheckedSet("users._ghosts")

--- a/src/users.py
+++ b/src/users.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import fnmatch
 import time
 import re
-from typing import Callable, Optional, Set
+from typing import Callable, List, Optional, Set
 
 from src.context import IRCContext, Features, lower, equals
 from src import settings as var
@@ -10,16 +12,16 @@ from src.events import EventListener
 from src.debug import CheckedDict, CheckedSet
 from src.match import Match
 
-import botconfig
+import botconfig  # type: ignore
 
 __all__ = ["Bot", "predicate", "get", "add", "users", "disconnected", "complete_match",
            "parse_rawnick", "parse_rawnick_as_dict", "User", "FakeUser", "BotUser"]
 
-Bot = None # bot instance
+Bot: Optional[BotUser] = None # bot instance
 
-_users = CheckedSet("users._users") # type: CheckedSet[User]
-_ghosts = CheckedSet("users._ghosts") # type: CheckedSet[User]
-_pending_account_updates = CheckedDict("users._pending_account_updates") # type: CheckedDict[User, CheckedDict[str, Callable]]
+_users: CheckedSet[User] = CheckedSet("users._users")
+_ghosts: CheckedSet[User] = CheckedSet("users._ghosts")
+_pending_account_updates: CheckedDict[User, CheckedDict[str, Callable]] = CheckedDict("users._pending_account_updates")
 
 _arg_msg = "(user={0:for_tb}, allow_bot={1})"
 
@@ -133,7 +135,7 @@ def complete_match(pattern: str, scope=None):
     """
     if scope is None:
         scope = _users
-    matches = []
+    matches: List[User] = []
     nick_search, _, acct_search = lower(pattern).partition(":")
     if not nick_search and not acct_search:
         return Match([])
@@ -222,6 +224,8 @@ EventListener(_update_account).install("who_end")
 class User(IRCContext):
 
     is_user = True
+
+    account_timestamp: float
 
     def __new__(cls, cli, nick, ident, host, account):
         self = super().__new__(cls)

--- a/src/votes.py
+++ b/src/votes.py
@@ -1,9 +1,12 @@
+from __future__ import annotations
+
 from collections import Counter
 from datetime import datetime, timedelta
 import random
 import copy
 import math
 import re
+from typing import TYPE_CHECKING
 
 from src.containers import UserDict, UserList, UserSet
 from src.decorators import command, event_listener
@@ -13,11 +16,14 @@ from src.status import try_absent, get_absent, get_forced_votes, get_all_forced_
 from src.events import Event
 from src import channels, pregame
 
-VOTES = UserDict() # type: UserDict[users.User, UserList[users.User]]
-ABSTAINS = UserSet() # type: UserList[users.User]
+if TYPE_CHECKING:
+    from src.users import User
+
+VOTES: UserDict[User, UserList] = UserDict()
+ABSTAINS: UserSet = UserSet()
 ABSTAINED = False
 LAST_VOTES = None
-LYNCHED = 0 # type: int
+LYNCHED: int = 0
 
 @command("lynch", playing=True, pm=True, phases=("day",))
 def lynch(var, wrapper, message):

--- a/src/warnings.py
+++ b/src/warnings.py
@@ -121,11 +121,9 @@ def add_warning(target: Union[str, users.User], amount: int, actor: users.User, 
         cmodes = []
         for acc in acclist:
             cmodes.append(("+b", "{0}{1}".format(var.ACCOUNT_PREFIX, acc)))
-        assert channels.Main is not None
         channels.Main.mode(*cmodes)
         for user in channels.Main.users:
             if user.account in acclist:
-                assert users.Bot is not None
                 channels.Main.kick(user, messages["tempban_kick"].format(nick=user, botnick=users.Bot.nick, reason=reason))
 
     # Update any tracking vars that may have changed due to this

--- a/src/warnings.py
+++ b/src/warnings.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 from datetime import datetime, timedelta
 from typing import Union, List, Optional
 import re
 
-import botconfig
+import botconfig  # type: ignore
 import src.settings as var
 from src import channels, db, users
 from src.lineparse import LineParser, LineParseError, WantsHelp
@@ -119,9 +121,11 @@ def add_warning(target: Union[str, users.User], amount: int, actor: users.User, 
         cmodes = []
         for acc in acclist:
             cmodes.append(("+b", "{0}{1}".format(var.ACCOUNT_PREFIX, acc)))
+        assert channels.Main is not None
         channels.Main.mode(*cmodes)
         for user in channels.Main.users:
             if user.account in acclist:
+                assert users.Bot is not None
                 channels.Main.kick(user, messages["tempban_kick"].format(nick=user, botnick=users.Bot.nick, reason=reason))
 
     # Update any tracking vars that may have changed due to this
@@ -212,25 +216,25 @@ def _parse_expires(expires: str, base: Optional[str] = None) -> Optional[datetim
         raise ValueError("amount cannot be negative")
 
     if not base:
-        base = datetime.utcnow()
+        base_dt = datetime.utcnow()
     else:
-        base = datetime.strptime(base, "%Y-%m-%d %H:%M:%S")
+        base_dt = datetime.strptime(base, "%Y-%m-%d %H:%M:%S")
 
     if suffix == messages.raw("day_suffix"):
-        expires = base + timedelta(days=amount)
+        expires_dt = base_dt + timedelta(days=amount)
     elif suffix == messages.raw("hour_suffix"):
-        expires = base + timedelta(hours=amount)
+        expires_dt = base_dt + timedelta(hours=amount)
     elif suffix == messages.raw("minute_suffix"):
-        expires = base + timedelta(minutes=amount)
+        expires_dt = base_dt + timedelta(minutes=amount)
     else:
         raise ValueError("unrecognized time suffix")
 
     round_add = 0
-    if expires.second >= 30:
+    if expires_dt.second >= 30:
         round_add = 1
-    expires -= timedelta(seconds=expires.second, microseconds=expires.microsecond)
-    expires += timedelta(minutes=round_add)
-    return expires
+    expires_dt -= timedelta(seconds=expires_dt.second, microseconds=expires_dt.microsecond)
+    expires_dt += timedelta(minutes=round_add)
+    return expires_dt
 
 def warn_list(var, wrapper, args):
     if args.help:

--- a/src/wolfgame.py
+++ b/src/wolfgame.py
@@ -1565,7 +1565,6 @@ def on_kill_players(evt: Event, var, players: Set[User]):
 
     # attempt to devoice all dead players
     if cmode:
-        assert channels.Main is not None
         channels.Main.mode(*cmode)
 
     if not evt.params.end_game:

--- a/src/wolfgame.py
+++ b/src/wolfgame.py
@@ -19,6 +19,8 @@
 # OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
 # ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import annotations
+
 import copy
 import fnmatch
 import functools
@@ -41,13 +43,13 @@ import urllib.request
 
 from collections import defaultdict, deque, Counter
 from datetime import datetime, timedelta
-from typing import Set, Optional, Callable, Tuple
+from typing import TYPE_CHECKING, Set, Optional, Callable, Tuple
 
 from oyoyo.parse import parse_nick
 
-import botconfig
+import botconfig  # type: ignore
 import src
-import src.settings as var
+import src.settings as var  # type: ignore
 from src.utilities import *
 from src import db, events, dispatcher, channels, users, hooks, logger, debuglog, errlog, plog, cats, handler
 from src.users import User
@@ -72,62 +74,65 @@ from src.functions import (
     get_target, change_role, match_role, match_mode
    )
 
+if TYPE_CHECKING:
+    from src.channels import Channel
+
 # done this way so that events is accessible in !eval (useful for debugging)
 Event = events.Event
 EventListener = events.EventListener
 
 # Game Logic Begins:
 
-var.LAST_STATS = None
-var.LAST_ADMINS = None
-var.LAST_GSTATS = None
-var.LAST_PSTATS = None
-var.LAST_RSTATS = None
-var.LAST_TIME = None
-var.LAST_GOAT = UserDict() # type: UserDict[users.User, datetime]
+var.LAST_STATS = None  # type: ignore
+var.LAST_ADMINS = None  # type: ignore
+var.LAST_GSTATS = None  # type: ignore
+var.LAST_PSTATS = None  # type: ignore
+var.LAST_RSTATS = None  # type: ignore
+var.LAST_TIME = None  # type: ignore
+var.LAST_GOAT = UserDict() # type: ignore # actually UserDict[users.User, datetime]
 
-var.ADMIN_PINGING = False
-var.DCED_LOSERS = UserSet()
-var.ADMIN_TO_PING = None
-var.AFTER_FLASTGAME = None
-var.PINGING_IFS = False
-var.TIMERS = {}
-var.PHASE = "none"
-var.OLD_MODES = defaultdict(set)
+var.ADMIN_PINGING = False  # type: ignore
+var.DCED_LOSERS = UserSet()  # type: ignore
+var.ADMIN_TO_PING = None  # type: ignore
+var.AFTER_FLASTGAME = None  # type: ignore
+var.PINGING_IFS = False  # type: ignore
+var.TIMERS = {}  # type: ignore
+var.PHASE = "none"  # type: ignore
+var.OLD_MODES = defaultdict(set)  # type: ignore
 
-var.ROLES = UserDict() # type: UserDict[str, UserSet]
-var.ORIGINAL_ROLES = UserDict() # type: UserDict[str, UserSet]
-var.MAIN_ROLES = UserDict() # type: UserDict[users.User, str]
-var.ORIGINAL_MAIN_ROLES = UserDict() # type: UserDict[users.User, str]
-var.FINAL_ROLES = UserDict() # type: UserDict[users.User, str]
-var.ALL_PLAYERS = UserList()
-var.FORCE_ROLES = DefaultUserDict(UserSet)
-var.ORIGINAL_ACCS = UserDict() # type: UserDict[users.User, str]
+var.ROLES = UserDict() # type: ignore # actually UserDict[str, UserSet]
+var.ORIGINAL_ROLES = UserDict() # type: ignore # actually UserDict[str, UserSet]
+var.MAIN_ROLES = UserDict() # type: ignore # actually UserDict[users.User, str]
+var.ORIGINAL_MAIN_ROLES = UserDict() # type: ignore # actually UserDict[users.User, str]
+var.FINAL_ROLES = UserDict() # type: ignore # actually UserDict[users.User, str]
+var.ALL_PLAYERS = UserList() # type: ignore
+var.FORCE_ROLES = DefaultUserDict(UserSet) # type: ignore
+var.ORIGINAL_ACCS = UserDict() # type: ignore # actually UserDict[users.User, str]
 
-var.IDLE_WARNED = UserSet()
-var.IDLE_WARNED_PM = UserSet()
-var.NIGHT_IDLED = UserSet()
-var.NIGHT_IDLE_EXEMPT = UserSet()
+var.IDLE_WARNED = UserSet() # type: ignore
+var.IDLE_WARNED_PM = UserSet() # type: ignore
+var.NIGHT_IDLED = UserSet() # type: ignore
+var.NIGHT_IDLE_EXEMPT = UserSet() # type: ignore
 
-var.DEAD = UserSet()
+var.DEAD = UserSet() # type: ignore
 
-var.DEADCHAT_PLAYERS = UserSet()
+var.DEADCHAT_PLAYERS = UserSet() # type: ignore
 
-var.SPECTATING_WOLFCHAT = UserSet()
-var.SPECTATING_DEADCHAT = UserSet()
+var.SPECTATING_WOLFCHAT = UserSet() # type: ignore
+var.SPECTATING_DEADCHAT = UserSet() # type: ignore
 
-var.ORIGINAL_SETTINGS = {}
-var.GAMEMODE_VOTES = UserDict()
+var.ORIGINAL_SETTINGS = {} # type: ignore
+var.GAMEMODE_VOTES = UserDict() # type: ignore
 
-var.LAST_SAID_TIME = UserDict()
+var.LAST_SAID_TIME = UserDict() # type: ignore
 
-var.GAME_START_TIME = datetime.now()  # for idle checker only
-var.CAN_START_TIME = 0
-var.STARTED_DAY_PLAYERS = 0
+var.GAME_START_TIME = datetime.now()  # type: ignore # for idle checker only
+var.CAN_START_TIME = 0 # type: ignore
+var.STARTED_DAY_PLAYERS = 0 # type: ignore
 
-var.DISCONNECTED = UserDict() # type: UserDict[User, Tuple[datetime, str]]
+var.DISCONNECTED = UserDict() # type: ignore # actually UserDict[User, Tuple[datetime, str]]
 
-var.RESTARTING = False
+var.RESTARTING = False # type: ignore
 
 if botconfig.DEBUG_MODE and var.DISABLE_DEBUG_MODE_TIMERS:
     var.NIGHT_TIME_LIMIT = 0 # 120
@@ -953,6 +958,7 @@ def fjoin(var, wrapper: MessageDispatcher, message: str):
 
     parts = re.split(" +", message)
     to_join = []
+    assert isinstance(wrapper.target, Channel)
     if not botconfig.DEBUG_MODE:
         match = users.complete_match(parts[0], wrapper.target.users)
         if match:
@@ -1559,6 +1565,7 @@ def on_kill_players(evt: Event, var, players: Set[User]):
 
     # attempt to devoice all dead players
     if cmode:
+        assert channels.Main is not None
         channels.Main.mode(*cmode)
 
     if not evt.params.end_game:

--- a/src/wolfgame.py
+++ b/src/wolfgame.py
@@ -958,7 +958,6 @@ def fjoin(var, wrapper: MessageDispatcher, message: str):
 
     parts = re.split(" +", message)
     to_join = []
-    assert isinstance(wrapper.target, Channel)
     if not botconfig.DEBUG_MODE:
         match = users.complete_match(parts[0], wrapper.target.users)
         if match:

--- a/wolfbot.py
+++ b/wolfbot.py
@@ -21,7 +21,7 @@ import traceback
 import sys
 import os
 
-import botconfig
+import botconfig  # type: ignore
 
 ver = sys.version_info
 if ver < (3, 7):
@@ -30,7 +30,7 @@ if ver < (3, 7):
     sys.exit(1)
 
 try: # need to manually add dependencies here
-    import antlr4
+    import antlr4  # type: ignore
 except ImportError:
     command = "python3"
     if os.name == "nt":


### PR DESCRIPTION
NOTE: Testingwise I ended up running this and doing a `!join` then a `!quit`, although that was after the first commit and I missed one `from __future__ import annotations` line so I needed another commit. This does touch a lot of files and I'm not sure how you want this PR to be arranged.

If a `botconfig.py` is not provided then running mypy like this (available on pip) should pass:

```
python3 -m mypy .
```

This is good enough to get mypy 0.812 to typecheck things successfully in non-strict mode, although a custom mypy.ini was provided to ignore all failures in `src.messages.*`.

A large chunk of type comments were turned into Python 3.5/3.6 inline annotations.

`from __future__ import annotations` allows Python 3.7+ to not actually attempt to resolve type names when it sees said inline annotations.

Various imports are guarded by the `typing.TYPE_CHECKING` variable so not to introduce potential import loops into the code.

Several assertions were put in places to make mypy happy. In most cases, if the assertions were not there, the code would have crashed anyway.

`UserSet` and `UserList` were confirmed to not need to be generic. `UserDict` on the other hand seemed like the key or the value could be not a `User` and therefore both key and value needed to be generic.

Several cases of `users.User`, mostly those in annotations and type comments, were changed to be just `User`.

`src/settings.py` was for the purposes of this commit deemed to be something longing to be killed with fire and as a result I've largely avoided giving it proper type annotations for some things, especially where it gets extra stuff dumped into it for no reason from `src/wolfgame.py`.

A bug was fixed in `src/status/dying.py` as a result of needing to get the types checked. `None` is falsy, but it was meant to return `True` rather than do a no-value return (which returns `None`). I'm not sure if we want to split this one out or not. (The other case of a no-value return being changed was due to it actually needing to return `None`, so the change is behaviourally-identical.)