### PR TITLE
Set default for night warning timer back to 1:30

### DIFF
--- a/src/defaultsettings.yml
+++ b/src/defaultsettings.yml
@@ -971,7 +971,7 @@ timers: &timers
             A warning is printed to channel that night is almost over at this time.
             Must be less than timers.night.limit.
           _type: int
-          _default: 60
+          _default: 90
     day:
       _desc: Time limits related to the day phase.
       _type: dict


### PR DESCRIPTION
This was changed to 1:00 with the refactor, which made it not match the language of the warning message sent to the channel ("the night is almost over").

Fixed #489 