### PR TITLE
Remove day phase check from piper win condition

### DIFF
--- a/src/roles/piper.py
+++ b/src/roles/piper.py
@@ -107,7 +107,7 @@ def on_chk_win(evt: Event, var: GameState, rolemap: dict[str, set[User]], mainro
 
     uncharmed = set(get_players(var, mainroles=mainroles)) - CHARMED - pipers
 
-    if var.current_phase == "day" and not uncharmed:
+    if not uncharmed:
         evt.data["winner"] = "pipers"
         evt.data["message"] = messages["piper_win"].format(lp)
 


### PR DESCRIPTION
The win condition for piper checked whether the current phase was "day". This meant that games that ended on the day transition (e.g. the last uncharmed player got charmed overnight) weren't resolving properly if other roles' win conditions triggered on the same transition (e.g. wolves killed enough people to win at the same time). Additionally, if other roles didn't have a win condition, the game would transition fully to day (lynch instructions and all) and then end the game, which looked odd.

Back in ye olden days, this check was needed because charmings were applied immediately (i.e. without the check, a game might end right after the piper charmed, because all players would then be charmed). However, a separate variable TOBECHARMED now holds newly-charmed players during night and they're added to the CHARMED list during the day transition, so this check seems to be redundant now.

Discussed with moonmoon on IRC, as far as we can tell the only other behavior difference caused by this change should be that wins due to idling (i.e. last uncharmed person idles out) should now resolve immediately instead of waiting until day time, which seems fine to us.

Tested in debug mode in 6p and 8p charming with a few different win types and player behaviors, not seeing any additional issues.

Closes #488, closes #501