### PR TITLE
still prune users from state when there's no active game

### DIFF
--- a/src/users.py
+++ b/src/users.py
@@ -207,9 +207,7 @@ def _cleanup_user(evt, var: GameState, user: User):
     # if user is in-game, keep them around so that other players can act on them
     # and so that they can return to the village. If they aren't in game, erase
     # all memory of them from the bot.
-    if not var:
-        return
-    if var.in_game and user in var.players:
+    if var and var.in_game and user in var.players:
         user.disconnected = True
     else:
         user.disconnected = False


### PR DESCRIPTION
the code as it currently is won't clean up a user when they part the only channel they share with lykos, which means if they rejoin with different details (i.e. changed ident) there will be a version of them still in state (but in no channels!) which causes `users.py::get()` to find multiple potential users