### PR TITLE
Clear PASSED when GA guards

### DIFF
--- a/src/roles/angel.py
+++ b/src/roles/angel.py
@@ -42,6 +42,7 @@ def guard(wrapper: MessageDispatcher, message: str):
         return
 
     add_protection(var, target, wrapper.source, "guardian angel")
+    PASSED.discard(wrapper.source)
     GUARDED[wrapper.source] = target
     LASTGUARDED[wrapper.source] = target
 


### PR DESCRIPTION
This stops GA from double-counting as having done their role (meaning that someone else's roll action can get skipped) for purposes of night ending.

Fixes #514

Tested in debug mode using the transcript in 514, seems to work fine.