### PR TITLE
Clean up lover logic

### DIFF
--- a/src/gamemodes/__init__.py
+++ b/src/gamemodes/__init__.py
@@ -295,7 +295,7 @@ class GameMode:
         if winner in Win_Stealer:
             return # fool won, lovers can't win even if they would
         from src.roles.matchmaker import get_all_lovers
-        all_lovers = get_all_lovers()
+        all_lovers = get_all_lovers(var)
         if len(all_lovers) != 1:
             return # we need exactly one cluster alive for this to trigger
 

--- a/src/gamemodes/__init__.py
+++ b/src/gamemodes/__init__.py
@@ -294,8 +294,8 @@ class GameMode:
         winner = evt.data["winner"]
         if winner in Win_Stealer:
             return # fool won, lovers can't win even if they would
-        from src.roles.matchmaker import get_lovers
-        all_lovers = get_lovers(var)
+        from src.roles.matchmaker import get_all_lovers
+        all_lovers = get_all_lovers()
         if len(all_lovers) != 1:
             return # we need exactly one cluster alive for this to trigger
 

--- a/src/roles/matchmaker.py
+++ b/src/roles/matchmaker.py
@@ -67,7 +67,7 @@ def get_all_lovers(var: GameState) -> list[set[User]]:
 
     return lovers
 
-def get_lovers(var: GameState, player: User, include_player: bool = False) -> set[User]:
+def get_lovers(var: GameState, player: User, *, include_player: bool = False) -> set[User]:
     """ Get all alive players this player is currently in love with.
 
     :param var: Game state

--- a/src/roles/matchmaker.py
+++ b/src/roles/matchmaker.py
@@ -27,7 +27,7 @@ PAIRINGS: UserDict[User, UserSet] = UserDict()
 
 def _set_lovers(target1: User, target2: User):
     # ensure that PAIRINGS maps lower id to higher ids
-    if target2.account < target1.account:
+    if target2 < target1:
         target1, target2 = target2, target1
 
     if target1 in PAIRINGS:

--- a/src/users.py
+++ b/src/users.py
@@ -387,6 +387,14 @@ class User(IRCContext):
                 and self.host == other.host
                 and self.account == other.account)
 
+    def __lt__(self, other):
+        if not isinstance(other, User):
+            return NotImplemented
+
+        self_comp = self.name if self.is_fake else self.account
+        other_comp = other.name if other.is_fake else other.account
+        return self_comp < other_comp
+
     def partial_match(self, other):
         """Test if our non-None properties match the non-None properties on the other object.
 


### PR DESCRIPTION
This gets rid of a lot of nested loops by making proper use of the adjacency list datastructure already in place to traverse through the lovers graph. A second graph containing forward edges only is maintained for revealroles and endgame display, so that the main lovers graph can be pruned as people die and therefore simplify a lot of other logic.

For the second graph, we map in order of lower accountname to higher accountname, since this is guaranteed to be stable throughout the course of a game.